### PR TITLE
feat: redesign primary navigation sidebar

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,4 +1,3 @@
-
 import React, { useEffect, useState, type FC } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -8,12 +7,46 @@ import { isFeatureEnabled } from '../shared/config/featureFlags';
 import { CommandPalette } from '../widgets/command-palette/CommandPalette';
 import { NotificationCenter } from '../widgets/notification-center/NotificationCenter';
 
+import { NavigationIcon } from './NavigationIcon';
 import { appNavigation, type NavigationItem } from './navigation';
 
 const AppShell: FC = () => {
   const { t } = useTranslation();
   const { user, logout, hasPermission } = useAuth();
   const [isPaletteOpen, setPaletteOpen] = useState(false);
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    appNavigation.forEach((section, index) => {
+      initial[section.title] = index < 2;
+    });
+    return initial;
+  });
+
+  const brandLabel = t('brand.name', { defaultValue: 'NETGRIP NOC' });
+
+  const toggleSection = (title: string) => {
+    setExpandedSections(previous => ({
+      ...previous,
+      [title]: !previous[title],
+    }));
+  };
+
+  const visibleSections = appNavigation
+    .map(section => ({
+      ...section,
+      items: section.items.filter(item => {
+        const enabledByFlag = item.featureFlag ? isFeatureEnabled(item.featureFlag) : true;
+        if (!enabledByFlag) return false;
+
+        if (item.permission) {
+          const permissions = Array.isArray(item.permission) ? item.permission : [item.permission];
+          return permissions.some(permission => hasPermission(permission));
+        }
+
+        return true;
+      }),
+    }))
+    .filter(section => section.items.length > 0);
 
   useEffect(() => {
     const handleHotkey = (event: KeyboardEvent) => {
@@ -30,60 +63,74 @@ const AppShell: FC = () => {
     return () => window.removeEventListener('keydown', handleHotkey);
   }, []);
 
-
-  const renderItem = (item: NavigationItem) => {
-    const enabledByFlag = item.featureFlag ? isFeatureEnabled(item.featureFlag) : true;
-    if (!enabledByFlag) return null;
-
-    if (item.permission) {
-      const permissions = Array.isArray(item.permission) ? item.permission : [item.permission];
-      const canAccess = permissions.some(permission => hasPermission(permission));
-      if (!canAccess) return null;
-    }
-
-    return (
-      <NavLink
-        key={item.path}
-        to={item.path}
-        className={({ isActive }) =>
-          [
-            'group flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900',
-            isActive
-              ? 'bg-white/10 text-white shadow-sm'
-              : 'text-neutral-300 hover:bg-white/5 hover:text-white',
-          ].join(' ')
-        }
-      >
-        <span className="truncate">
-          {item.translationKey ? t(item.translationKey, { defaultValue: item.title }) : item.title}
-        </span>
-      </NavLink>
-    );
-  };
+  const renderItem = (item: NavigationItem) => (
+    <NavLink
+      key={item.path}
+      to={item.path}
+      className={({ isActive }) =>
+        [
+          'nav-link group relative flex items-center gap-3 rounded-lg px-4 py-2.5 text-xs font-semibold uppercase tracking-[0.18em] transition',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950/80',
+          isActive ? 'is-active' : '',
+        ].join(' ')
+      }
+    >
+      <span className="nav-link__highlight" aria-hidden />
+      <NavigationIcon name={item.icon} className="nav-link__icon" />
+      <span className="nav-link__label">
+        {item.translationKey ? t(item.translationKey, { defaultValue: item.title }) : item.title}
+      </span>
+      <span className="nav-link__glow" aria-hidden />
+    </NavLink>
+  );
 
   return (
     <div className="app-shell grid min-h-screen grid-cols-[280px_1fr] grid-rows-[56px_1fr] text-neutral-100">
-      <aside className="app-shell__sidebar col-start-1 row-span-2 flex min-h-0 flex-col border-r border-white/10 bg-slate-950/75 px-6 py-8">
-        <div className="flex items-center justify-between gap-3 px-1">
-          <span className="brand text-sm font-semibold uppercase tracking-[0.24em] text-white">
-            {t('brand.name', { defaultValue: 'NetGrip NOC' })}
-          </span>
+      <aside className="app-shell__sidebar col-start-1 row-span-2 flex min-h-0 flex-col px-6 py-8">
+        <div className="brand" aria-label={brandLabel}>
+          <span className="brand__glow" aria-hidden />
+          <span className="brand__label">{brandLabel}</span>
         </div>
         <nav
           className="app-shell__nav mt-8 space-y-6"
           aria-label={t('navigation.primary', { defaultValue: 'Primary navigation' })}
         >
-          {appNavigation.map(section => (
-            <section key={section.title} className="space-y-3">
-              <p className="nav-section__title px-3 text-xs font-medium uppercase tracking-[0.2em] text-neutral-400/80">
-                {section.translationKey
-                  ? t(section.translationKey, { defaultValue: section.title })
-                  : section.title}
-              </p>
-              <div className="space-y-1">{section.items.map(renderItem)}</div>
-            </section>
-          ))}
+          {visibleSections.map(section => {
+            const isExpanded = expandedSections[section.title] ?? true;
+            const sectionId = `nav-section-${section.title.toLowerCase().replace(/[^a-z0-9]+/gi, '-')}`;
+
+            return (
+              <section key={section.title} className="nav-section">
+                <button
+                  type="button"
+                  className="nav-section__toggle"
+                  onClick={() => toggleSection(section.title)}
+                  aria-expanded={isExpanded}
+                  aria-controls={sectionId}
+                >
+                  <span className="nav-section__title">
+                    {section.translationKey
+                      ? t(section.translationKey, { defaultValue: section.title })
+                      : section.title}
+                  </span>
+                  <span className="nav-section__chevron" aria-hidden data-expanded={isExpanded}>
+                    <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M5 8.25L10 12.75L15 8.25"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <div id={sectionId} className="nav-section__items" data-expanded={isExpanded}>
+                  {isExpanded && section.items.map(renderItem)}
+                </div>
+              </section>
+            );
+          })}
         </nav>
       </aside>
       <header className="app-shell__header sticky top-0 col-start-2 row-start-1 flex h-14 items-center justify-between gap-4 border-b border-white/10 px-6">

--- a/src/app/NavigationIcon.tsx
+++ b/src/app/NavigationIcon.tsx
@@ -1,0 +1,172 @@
+/* eslint-disable react/prop-types */
+import React, { memo, type ReactElement } from 'react';
+
+type NavigationIconName =
+  | 'dashboard'
+  | 'route'
+  | 'inventory'
+  | 'topology'
+  | 'leases'
+  | 'bell'
+  | 'incident'
+  | 'reports'
+  | 'leader'
+  | 'robot'
+  | 'passport'
+  | 'shield'
+  | 'roles'
+  | 'settings';
+
+const ICONS: Record<NavigationIconName | 'default', ReactElement> = {
+  dashboard: (
+    <>
+      <rect x="3" y="3" width="6.5" height="6.5" rx="1.4" />
+      <rect x="10.5" y="3" width="6.5" height="4.25" rx="1.4" />
+      <rect x="10.5" y="8.25" width="6.5" height="8.75" rx="1.4" />
+      <rect x="3" y="10.75" width="6.5" height="6.25" rx="1.4" />
+    </>
+  ),
+  route: (
+    <>
+      <path d="M5.5 4.5c1.75 0 3.17 1.45 3.17 3.24 0 1.79-1.42 3.24-3.17 3.24" />
+      <path d="M14.5 12.82c-1.75 0-3.17-1.45-3.17-3.24 0-1.79 1.42-3.24 3.17-3.24" />
+      <path d="M5.5 11H12" />
+      <circle cx="5.5" cy="4.5" r="2.25" />
+      <circle cx="14.5" cy="15.5" r="2.25" />
+      <circle cx="14.5" cy="6.5" r="2.25" />
+    </>
+  ),
+  inventory: (
+    <>
+      <path d="M4 6.25 10 3l6 3.25" />
+      <path d="M4 10.25 10 7l6 3.25" />
+      <path d="M4 14.25 10 11l6 3.25" />
+      <path d="M4 6.25v8" />
+      <path d="M16 6.25v8" />
+    </>
+  ),
+  topology: (
+    <>
+      <circle cx="10" cy="5" r="2.4" />
+      <circle cx="5.5" cy="14.5" r="2.4" />
+      <circle cx="14.5" cy="14.5" r="2.4" />
+      <path d="M10 7.4v3.2" />
+      <path d="M8.4 12 6.8 13.6" />
+      <path d="M11.6 12 13.2 13.6" />
+    </>
+  ),
+  leases: (
+    <>
+      <path d="M5.25 4.5h9.5c.7 0 1.25.56 1.25 1.25v6.5c0 .69-.55 1.25-1.25 1.25H5.25c-.69 0-1.25-.56-1.25-1.25v-6.5C4 5.06 4.56 4.5 5.25 4.5Z" />
+      <path d="M7.25 8.5H8.5" />
+      <path d="M11.5 8.5h1.25" />
+      <path d="M9.25 12v3" />
+      <circle cx="9.25" cy="15.5" r="1.5" />
+    </>
+  ),
+  bell: (
+    <>
+      <path d="M10 16.5c1.24 0 2.25-1 2.25-2.25h-4.5c0 1.24 1 2.25 2.25 2.25Z" />
+      <path d="M5.5 11.5V9.75a4.5 4.5 0 1 1 9 0v1.75l1.25 1.88c.34.52-.02 1.21-.64 1.21H4.89c-.62 0-.98-.69-.64-1.21L5.5 11.5Z" />
+    </>
+  ),
+  incident: (
+    <>
+      <path d="M10 4.25 4.25 15.75h11.5L10 4.25Z" />
+      <path d="M10 8.75v3.5" />
+      <circle cx="10" cy="13.25" r="0.7" />
+    </>
+  ),
+  reports: (
+    <>
+      <path d="M6 4h8c.83 0 1.5.67 1.5 1.5v9c0 .83-.67 1.5-1.5 1.5H6c-.83 0-1.5-.67-1.5-1.5v-9C4.5 4.67 5.17 4 6 4Z" />
+      <path d="M7.25 7.25h5.5" />
+      <path d="M7.25 10h5.5" />
+      <path d="M7.25 12.75h3" />
+    </>
+  ),
+  leader: (
+    <>
+      <circle cx="10" cy="6.25" r="2.25" />
+      <path d="M10 9c-2.76 0-5 2.02-5 4.51V15c0 .55.45 1 1 1h8c.55 0 1-.45 1-1v-1.49C15 11.02 12.76 9 10 9Z" />
+      <path d="m14.75 4.75 1.5-1.5" />
+      <path d="M14.5 7.25h2" />
+      <path d="m14.75 5.5 1.75.75" />
+    </>
+  ),
+  robot: (
+    <>
+      <rect x="4.5" y="6" width="11" height="8.5" rx="2.25" />
+      <path d="M8 16.25h4" />
+      <circle cx="8.25" cy="10.25" r="1.05" />
+      <circle cx="12.75" cy="10.25" r="1.05" />
+      <path d="M10 4V2.75" />
+      <path d="M6 4V2.5" />
+      <path d="M14 4V2.5" />
+    </>
+  ),
+  passport: (
+    <>
+      <rect x="6" y="4" width="8" height="12" rx="1.8" />
+      <path d="M10 4v12" />
+      <path d="M7.5 7.25h5" />
+      <path d="M7.5 10h5" />
+      <path d="M7.5 12.75h5" />
+    </>
+  ),
+  shield: (
+    <>
+      <path d="M10 17c-3.25-1.3-5.5-3.9-5.5-8.1V5.35c0-.48.32-.9.78-1.02L10 3.25l4.72 1.08c.46.11.78.53.78 1.02v3.55c0 4.2-2.25 6.8-5.5 8.1Z" />
+      <path d="M10 7.5v3" />
+      <circle cx="10" cy="12.25" r="0.75" />
+    </>
+  ),
+  roles: (
+    <>
+      <circle cx="7.25" cy="7.25" r="2.25" />
+      <path d="M7.25 10.25c-2.1 0-3.8 1.62-3.8 3.61V15c0 .55.45 1 1 1H9" />
+      <circle cx="13.5" cy="9" r="2.25" />
+      <path d="M13.5 11.75c1.84 0 3.25 1.42 3.25 3.15V15c0 .55-.45 1-1 1h-4.75" />
+    </>
+  ),
+  settings: (
+    <>
+      <circle cx="10" cy="10" r="2.35" />
+      <path d="m10 5.25.7-.4a1 1 0 0 1 1.5.74l.08.78c.02.25.2.47.43.57l.73.32a1 1 0 0 1 .46 1.43l-.41.68c-.12.2-.12.45 0 .65l.41.68a1 1 0 0 1-.46 1.43l-.73.32a.75.75 0 0 0-.43.57l-.08.78a1 1 0 0 1-1.5.74L10 14.75c-.21-.12-.48-.12-.69 0l-.7.4a1 1 0 0 1-1.5-.74l-.08-.78a.75.75 0 0 0-.43-.57l-.73-.32a1 1 0 0 1-.46-1.43l.41-.68c.12-.2.12-.45 0-.65l-.41-.68a1 1 0 0 1 .46-1.43l.73-.32c.23-.1.41-.32.43-.57l.08-.78a1 1 0 0 1 1.5-.74l.7.4c.21.12.48.12.69 0Z" />
+    </>
+  ),
+  default: (
+    <>
+      <circle cx="10" cy="10" r="1.5" />
+      <path d="M5 5h10v10H5z" />
+    </>
+  ),
+};
+
+export interface NavigationIconProps {
+  name?: string;
+  className?: string;
+}
+
+export const NavigationIcon = memo<NavigationIconProps>(({ name, className }) => {
+  const hasIcon = typeof name === 'string' && Object.prototype.hasOwnProperty.call(ICONS, name);
+  const iconKey = hasIcon ? (name as NavigationIconName) : 'default';
+  const iconNode = ICONS[iconKey];
+
+  return (
+    <svg
+      className={['nav-icon', className].filter(Boolean).join(' ')}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      focusable="false"
+    >
+      <g stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+        {iconNode}
+      </g>
+    </svg>
+  );
+});
+
+NavigationIcon.displayName = 'NavigationIcon';

--- a/src/styles/app/_app-shell.css
+++ b/src/styles/app/_app-shell.css
@@ -1,6 +1,11 @@
 .app-shell {
-  background: radial-gradient(1100px 700px at 70% 10%, rgba(255, 255, 255, 0.04), transparent), #0b0f16;
+  --accent: #2ff1ff;
+  --accent-soft: rgba(47, 241, 255, 0.35);
+  --sidebar-surface: radial-gradient(120% 120% at 80% -20%, rgba(47, 241, 255, 0.16), transparent 55%),
+    radial-gradient(120% 90% at 10% 110%, rgba(168, 85, 247, 0.14), transparent 60%),
+    #05070d;
   color: #e2e8f0;
+  background: radial-gradient(1100px 700px at 70% 10%, rgba(255, 255, 255, 0.04), transparent), #02040a;
 }
 
 .app-shell * {
@@ -8,29 +13,228 @@
 }
 
 .app-shell__sidebar {
+  position: relative;
   width: 280px;
-  backdrop-filter: blur(12px);
+  border-right: 1px solid rgba(148, 163, 184, 0.16);
+  background: var(--sidebar-surface);
+  overflow: hidden;
 }
 
-.app-shell__sidebar .brand {
-  letter-spacing: 0.24em;
+.app-shell__sidebar::before,
+.app-shell__sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
-.nav-section__title {
-  letter-spacing: 0.18em;
+.app-shell__sidebar::before {
+  background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.08) 1px, transparent 0);
+  background-size: 12px 12px;
+  opacity: 0.3;
+}
+
+.app-shell__sidebar::after {
+  background: radial-gradient(260px 260px at 90% 0%, rgba(47, 241, 255, 0.22), transparent),
+    radial-gradient(220px 220px at 0% 90%, rgba(236, 72, 153, 0.18), transparent);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.brand {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Poppins', 'Inter', 'Segoe UI', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  color: #f8fafc;
+  text-shadow: 0 0 14px rgba(47, 241, 255, 0.5);
+}
+
+.brand__label {
+  position: relative;
+  display: inline-flex;
+  gap: 0.4em;
+  padding-left: 0.2em;
+}
+
+.brand__glow {
+  position: absolute;
+  inset: -18px -24px;
+  border-radius: 28px;
+  background: radial-gradient(circle at 30% 30%, rgba(47, 241, 255, 0.35), transparent 65%);
+  filter: blur(18px);
+  opacity: 0.85;
 }
 
 .app-shell__header {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(11, 15, 22, 0.8);
-  backdrop-filter: blur(6px);
+  background: rgba(5, 9, 16, 0.82);
+  backdrop-filter: blur(16px);
 }
 
 .app-shell__content {
   background: linear-gradient(180deg, rgba(11, 15, 22, 0.65), rgba(17, 24, 39, 0.92));
   min-height: 0;
+}
+
+.nav-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nav-section__toggle {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.5rem 0.4rem;
+  border: none;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.65);
+  font-family: 'Poppins', 'Inter', 'Segoe UI', sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.25s ease;
+}
+
+.nav-section__toggle:hover,
+.nav-section__toggle:focus-visible {
+  color: rgba(226, 232, 240, 0.9);
+  outline: none;
+}
+
+.nav-section__toggle::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -0.2rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(148, 163, 184, 0.18), transparent);
+}
+
+.nav-section__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: rgba(226, 232, 240, 0.65);
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.nav-section__chevron[data-expanded='true'] {
+  transform: rotate(180deg);
+  color: rgba(148, 246, 255, 0.9);
+}
+
+.nav-section__items {
+  display: grid;
+  gap: 0.35rem;
+  padding-inline: 0.25rem;
+}
+
+.nav-link {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(226, 232, 240, 0.7);
+  text-shadow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.nav-link .nav-link__label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: 'Poppins', 'Inter', 'Segoe UI', sans-serif;
+  letter-spacing: 0.22em;
+}
+
+.nav-icon {
+  display: block;
+}
+
+.nav-link .nav-link__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  color: rgba(148, 163, 184, 0.75);
+  transition: color 0.28s ease;
+}
+
+.nav-link__highlight {
+  position: absolute;
+  inset: 0.4rem auto 0.4rem 0.2rem;
+  width: 0.25rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(47, 241, 255, 0.1), rgba(47, 241, 255, 0.8));
+  transform-origin: center;
+  transform: scaleY(0.1);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+}
+
+.nav-link__glow {
+  position: absolute;
+  inset: -30% -40%;
+  background: radial-gradient(circle at 10% 10%, rgba(47, 241, 255, 0.32), transparent 60%);
+  opacity: 0;
+  filter: blur(26px);
+  transition: opacity 0.35s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  border-color: rgba(47, 241, 255, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: rgba(248, 250, 252, 0.95);
+}
+
+.nav-link:hover .nav-link__icon,
+.nav-link:focus-visible .nav-link__icon {
+  color: var(--accent);
+}
+
+.nav-link:hover .nav-link__highlight,
+.nav-link:focus-visible .nav-link__highlight {
+  opacity: 0.75;
+  transform: scaleY(1);
+}
+
+.nav-link:hover .nav-link__glow,
+.nav-link:focus-visible .nav-link__glow {
+  opacity: 0.7;
+}
+
+.nav-link.is-active {
+  border-color: rgba(47, 241, 255, 0.55);
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  text-shadow: 0 0 12px rgba(47, 241, 255, 0.4);
+}
+
+.nav-link.is-active .nav-link__icon {
+  color: var(--accent);
+}
+
+.nav-link.is-active .nav-link__highlight {
+  opacity: 1;
+  transform: scaleY(1);
+  box-shadow: 0 0 16px var(--accent-soft);
+}
+
+.nav-link.is-active .nav-link__glow {
+  opacity: 0.95;
 }
 
 main ul {


### PR DESCRIPTION
## Summary
- redesign the application shell sidebar with a neon brand header, collapsible section toggles, and animated active states
- introduce a reusable NavigationIcon component that supplies consistent glyphs for navigation links
- refresh the sidebar styling to a futuristic dark theme with hover glows and state indicators

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cedb6b417483218b14e8277bf64321