### PR TITLE
Localize executive dashboard widgets

### DIFF
--- a/src/app/navigation.ts
+++ b/src/app/navigation.ts
@@ -224,7 +224,7 @@ export const appNavigation: NavigationSection[] = [
       },
       {
         path: '/executive-dashboard',
-        title: 'Исполнительный дашборд',
+        title: 'Дашборд для руководства',
         icon: 'leader',
         translationKey: 'navigation.executiveDashboard',
         element: ExecutiveDashboardPage,

--- a/src/features/reports/ReportsBuilderCanvas.tsx
+++ b/src/features/reports/ReportsBuilderCanvas.tsx
@@ -2,7 +2,12 @@ import React, { useId } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-const blockOptions = ['KPI Summary', 'Time Series', 'Capacity Table', 'Incident Timeline'] as const;
+const blockOptions = [
+  'Сводка KPI',
+  'Временной ряд',
+  'Таблица пропускной способности',
+  'Хронология инцидентов',
+] as const;
 
 type BlockOption = (typeof blockOptions)[number];
 
@@ -16,7 +21,11 @@ type ReportsBuilderForm = z.infer<typeof builderSchema>;
 
 export const ReportsBuilderCanvas: React.FC = () => {
   const { control, handleSubmit, watch } = useForm<ReportsBuilderForm>({
-    defaultValues: { name: 'Executive Weekly Snapshot', preset: 'week', blocks: ['KPI Summary'] },
+    defaultValues: {
+      name: 'Еженедельный обзор для руководства',
+      preset: 'week',
+      blocks: ['Сводка KPI'],
+    },
   });
 
   const blocks = watch('blocks');
@@ -73,16 +82,16 @@ export const ReportsBuilderCanvas: React.FC = () => {
     <section className="reports-builder">
       <header className="reports-builder__header">
         <div>
-          <h2>Reports Builder</h2>
-          <p className="muted">Compose drag-and-drop layouts and export PDF/CSV/XLSX.</p>
+          <h2>Конструктор отчётов</h2>
+          <p className="muted">Создавайте макеты методом перетаскивания и экспортируйте их в PDF/CSV/XLSX.</p>
         </div>
-        <span className="status-badge status-active">Live preview</span>
+        <span className="status-badge status-active">Предпросмотр в реальном времени</span>
       </header>
 
       <form className="reports-builder__form" onSubmit={onSubmit}>
         <div className="form-controls">
           <div className="form-field">
-            <label htmlFor={`${idPrefix}-name`}>Report name</label>
+            <label htmlFor={`${idPrefix}-name`}>Название отчёта</label>
             <Controller
               control={control}
               name="name"
@@ -90,7 +99,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
                 <input
                   {...field}
                   id={`${idPrefix}-name`}
-                  placeholder="Executive summary"
+                  placeholder="Сводка для руководства"
                   required
                 />
               )}
@@ -98,15 +107,15 @@ export const ReportsBuilderCanvas: React.FC = () => {
           </div>
 
           <div className="form-field">
-            <label htmlFor={`${idPrefix}-preset`}>Preset</label>
+            <label htmlFor={`${idPrefix}-preset`}>Предустановка</label>
             <Controller
               control={control}
               name="preset"
               render={({ field }) => (
                 <select {...field} id={`${idPrefix}-preset`}>
-                  <option value="day">Day</option>
-                  <option value="week">Week</option>
-                  <option value="month">Month</option>
+                  <option value="day">День</option>
+                  <option value="week">Неделя</option>
+                  <option value="month">Месяц</option>
                 </select>
               )}
             />
@@ -114,7 +123,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
         </div>
 
         <fieldset>
-          <legend>Blocks</legend>
+          <legend>Блоки</legend>
           <Controller
             control={control}
             name="blocks"
@@ -164,7 +173,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
                   strokeLinejoin="round"
                 />
               </svg>
-              <p>Report preview will appear here</p>
+              <p>Предпросмотр отчёта будет отображаться здесь</p>
             </div>
           ) : (
             <div className="preview-grid">
@@ -185,7 +194,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
                   </div>
                   <div className="builder-block__body">
                     <h3>{block}</h3>
-                    <p className="muted">Report preview will appear here</p>
+                    <p className="muted">Предпросмотр отчёта будет отображаться здесь</p>
                   </div>
                 </article>
               ))}
@@ -195,15 +204,15 @@ export const ReportsBuilderCanvas: React.FC = () => {
         <footer className="reports-builder__actions">
           <button type="submit" className="primary">
             <FormatIcon variant="pdf" />
-            Export PDF
+            Экспорт в PDF
           </button>
           <button type="button" className="secondary">
             <FormatIcon variant="csv" />
-            Export CSV
+            Экспорт в CSV
           </button>
           <button type="button" className="ghost">
             <FormatIcon variant="xlsx" />
-            Export XLSX
+            Экспорт в XLSX
           </button>
         </footer>
       </form>

--- a/src/pages/executive-dashboard/ExecutiveDashboardPage.tsx
+++ b/src/pages/executive-dashboard/ExecutiveDashboardPage.tsx
@@ -17,7 +17,7 @@ const ExecutiveDashboardPage: React.FC = () => (
     <div className="executive-dashboard__grid">
       <article className="dashboard-card">
         <header>
-          <span className="dashboard-card__title">SLA Compliance</span>
+          <span className="dashboard-card__title">Соблюдение SLA</span>
           <span className="dashboard-card__loader" aria-hidden>
             <svg viewBox="0 0 32 32">
               <circle cx="16" cy="16" r="12" stroke="rgba(51, 245, 255, 0.35)" strokeWidth="2" fill="none" />
@@ -38,7 +38,7 @@ const ExecutiveDashboardPage: React.FC = () => (
       </article>
       <article className="dashboard-card">
         <header>
-          <span className="dashboard-card__title">MTTR Trend</span>
+          <span className="dashboard-card__title">Динамика MTTR</span>
           <span className="dashboard-card__loader" aria-hidden>
             <svg viewBox="0 0 32 32">
               <circle cx="16" cy="16" r="12" stroke="rgba(124, 58, 237, 0.35)" strokeWidth="2" fill="none" />
@@ -65,7 +65,7 @@ const ExecutiveDashboardPage: React.FC = () => (
       </article>
       <article className="dashboard-card">
         <header>
-          <span className="dashboard-card__title">Incident Severity Mix</span>
+          <span className="dashboard-card__title">Распределение серьёзности инцидентов</span>
           <span className="dashboard-card__loader" aria-hidden>
             <svg viewBox="0 0 32 32">
               <circle cx="16" cy="16" r="12" stroke="rgba(248, 113, 113, 0.45)" strokeWidth="2" fill="none" />
@@ -91,7 +91,7 @@ const ExecutiveDashboardPage: React.FC = () => (
       </article>
       <article className="dashboard-card dashboard-card--wide">
         <header>
-          <span className="dashboard-card__title">Executive Summary</span>
+          <span className="dashboard-card__title">Сводка для руководства</span>
           <span className="dashboard-card__loader" aria-hidden>
             <svg viewBox="0 0 32 32">
               <circle cx="16" cy="16" r="12" stroke="rgba(148, 163, 184, 0.35)" strokeWidth="2" fill="none" />

--- a/src/shared/config/i18n.ts
+++ b/src/shared/config/i18n.ts
@@ -232,7 +232,7 @@ const resources = {
         alerts: 'Оповещения',
         automation: 'Плейбуки автоматизации',
         reports: 'Конструктор отчётов',
-        executiveDashboard: 'Исполнительный дашборд',
+        executiveDashboard: 'Дашборд для руководства',
         productPassports: 'Паспорта изделий',
         navigationCheck: 'Диагностика навигации',
         settings: 'Общие настройки',


### PR DESCRIPTION
## Summary
- translate the executive dashboard widget headings to Russian to match the surrounding copy
- rename the executive dashboard navigation label to the localized wording in both routing config and i18n resources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf25d43b0083219ac20649e8aa2b4c