### PR TITLE
Add scrolling to modal overlay

### DIFF
--- a/src/styles/components/_modal.css
+++ b/src/styles/components/_modal.css
@@ -9,7 +9,9 @@
   background-color: rgba(2, 6, 23, 0.72);
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 2rem 1.25rem;
   z-index: 1000;
   backdrop-filter: blur(12px);
 }
@@ -25,6 +27,8 @@
   box-shadow: 0 32px 72px rgba(1, 5, 14, 0.6);
   animation: modal-fade-in 0.3s ease-out;
   position: relative;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
 }
 
 .modal-content::after {


### PR DESCRIPTION
## Summary
- allow modal overlay to scroll and provide top padding to prevent full-screen lock
- constrain modal content height and enable internal scrolling for large content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2cf1ab9c8321976b2ee366301609