### PR TITLE
feat: connect passport wizard to inventory

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '../context/AuthContext';
 import { isFeatureEnabled } from '../shared/config/featureFlags';
+import { ProductPassportProvider } from '../features/product-passport/ProductPassportContext';
 import { CommandPalette } from '../widgets/command-palette/CommandPalette';
 import { NotificationCenter } from '../widgets/notification-center/NotificationCenter';
 
@@ -162,7 +163,9 @@ const AppShell: FC = () => {
       </header>
       <main className="app-shell__content col-start-2 row-start-2 min-h-0 overflow-auto p-6 md:p-10">
         <div className="container w-full">
-          <Outlet />
+          <ProductPassportProvider>
+            <Outlet />
+          </ProductPassportProvider>
         </div>
       </main>
       <CommandPalette isOpen={isPaletteOpen} onClose={() => setPaletteOpen(false)} />

--- a/src/features/product-passport/ProductPassportConstructor.tsx
+++ b/src/features/product-passport/ProductPassportConstructor.tsx
@@ -1,0 +1,695 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import {
+  DEFAULT_TEMPLATE_ID,
+  PassportSection,
+  PassportTemplate,
+  SerializableEntry,
+  SerializableRow,
+  SerializableSection,
+  createDefaultTemplate,
+  createEmptyTemplateStructure,
+  createEntry,
+  createRow,
+  createSection,
+  sectionsToSerializable,
+  structureToSections,
+} from './passportSchema';
+import { useProductPassport } from './ProductPassportContext';
+
+const TEMPLATES_STORAGE_KEY = 'product-passport-templates';
+
+const sanitizeTemplates = (value: unknown): PassportTemplate[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map(item => {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        typeof (item as { id?: unknown }).id !== 'string' ||
+        typeof (item as { name?: unknown }).name !== 'string'
+      ) {
+        return null;
+      }
+
+      const rawStructure = (item as { structure?: unknown }).structure;
+      if (!Array.isArray(rawStructure)) {
+        return null;
+      }
+
+      const structure = rawStructure
+        .map(section => {
+          if (
+            !section ||
+            typeof section !== 'object' ||
+            typeof (section as { title?: unknown }).title !== 'string'
+          ) {
+            return null;
+          }
+
+          const rows = (section as { rows?: unknown }).rows;
+          if (!Array.isArray(rows)) {
+            return null;
+          }
+
+          const normalizedRows = rows
+            .map(row => {
+              if (
+                !row ||
+                typeof row !== 'object' ||
+                typeof (row as { name?: unknown }).name !== 'string'
+              ) {
+                return null;
+              }
+
+              const entries = (row as { entries?: unknown }).entries;
+              if (!Array.isArray(entries)) {
+                return null;
+              }
+
+              const normalizedEntries = entries
+                .map(entry => {
+                  if (
+                    !entry ||
+                    typeof entry !== 'object' ||
+                    typeof (entry as { label?: unknown }).label !== 'string' ||
+                    typeof (entry as { value?: unknown }).value !== 'string'
+                  ) {
+                    return null;
+                  }
+
+                  return { label: (entry as { label: string }).label, value: (entry as { value: string }).value };
+                })
+                .filter((entry): entry is SerializableEntry => Boolean(entry));
+
+              return {
+                name: (row as { name: string }).name,
+                entries: normalizedEntries,
+              };
+            })
+            .filter((row): row is SerializableRow => Boolean(row));
+
+          return {
+            title: (section as { title: string }).title,
+            rows: normalizedRows,
+          };
+        })
+        .filter((section): section is SerializableSection => Boolean(section));
+
+      return {
+        id: (item as { id: string }).id,
+        name: (item as { name: string }).name,
+        structure,
+      };
+    })
+    .filter((template): template is PassportTemplate => Boolean(template));
+};
+
+export const ProductPassportConstructor: React.FC = () => {
+  const defaultTemplate = useMemo(() => createDefaultTemplate(), []);
+  const [templates, setTemplates] = useState<PassportTemplate[]>(() => [createDefaultTemplate()]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>(() => DEFAULT_TEMPLATE_ID);
+  const [activeTemplateId, setActiveTemplateId] = useState<string>(() => DEFAULT_TEMPLATE_ID);
+  const [sections, setSections] = useState<PassportSection[]>(() =>
+    structureToSections(createDefaultTemplate().structure),
+  );
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const { pendingTemplate, clearPendingTemplate } = useProductPassport();
+
+  const serializableStructure = useMemo<SerializableSection[]>(
+    () => sectionsToSerializable(sections),
+    [sections],
+  );
+
+  useEffect(() => {
+    if (!feedbackMessage) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setFeedbackMessage(null), 2600);
+    return () => window.clearTimeout(timeout);
+  }, [feedbackMessage]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(TEMPLATES_STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+
+      const parsed = sanitizeTemplates(JSON.parse(stored));
+      if (parsed.length === 0) {
+        return;
+      }
+
+      setTemplates(prev => {
+        const existingIds = new Set(prev.map(template => template.id));
+        const merged = [...prev];
+
+        parsed.forEach(template => {
+          if (existingIds.has(template.id)) {
+            return;
+          }
+
+          merged.push(template);
+        });
+
+        return merged;
+      });
+    } catch (error) {
+      console.error('Не удалось загрузить сохранённые шаблоны', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const customTemplates = templates.filter(template => template.id !== DEFAULT_TEMPLATE_ID);
+    window.localStorage.setItem(TEMPLATES_STORAGE_KEY, JSON.stringify(customTemplates));
+  }, [templates]);
+
+  useEffect(() => {
+    if (templates.some(template => template.id === activeTemplateId)) {
+      return;
+    }
+
+    const fallback = templates[0];
+    if (!fallback) {
+      return;
+    }
+
+    setSelectedTemplateId(fallback.id);
+    setActiveTemplateId(fallback.id);
+    setSections(structureToSections(fallback.structure));
+  }, [activeTemplateId, templates]);
+
+  useEffect(() => {
+    if (!pendingTemplate) {
+      return;
+    }
+
+    setTemplates(current => {
+      const nextTemplate: PassportTemplate = {
+        id: pendingTemplate.templateId,
+        name: pendingTemplate.templateName,
+        structure: pendingTemplate.structure,
+      };
+
+      const index = current.findIndex(template => template.id === pendingTemplate.templateId);
+      if (index >= 0) {
+        const updated = [...current];
+        updated[index] = nextTemplate;
+        return updated;
+      }
+
+      return [...current, nextTemplate];
+    });
+
+    setSections(structureToSections(pendingTemplate.structure));
+    setSelectedTemplateId(pendingTemplate.templateId);
+    setActiveTemplateId(pendingTemplate.templateId);
+
+    const sourceLabel =
+      pendingTemplate.source === 'inventory'
+        ? 'инвентаря'
+        : pendingTemplate.source === 'new-device'
+        ? 'созданного изделия'
+        : 'каталога моделей';
+
+    setFeedbackMessage(`Шаблон «${pendingTemplate.templateName}» применён из ${sourceLabel}.`);
+    clearPendingTemplate();
+  }, [pendingTemplate, clearPendingTemplate]);
+
+  const handleSectionTitleChange = (sectionId: string, title: string) => {
+    setSections(prev =>
+      prev.map(section => (section.id === sectionId ? { ...section, title } : section)),
+    );
+  };
+
+  const handleRowNameChange = (sectionId: string, rowId: string, name: string) => {
+    setSections(prev =>
+      prev.map(section => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+
+        return {
+          ...section,
+          rows: section.rows.map(row => (row.id === rowId ? { ...row, name } : row)),
+        };
+      }),
+    );
+  };
+
+  const handleEntryChange = (
+    sectionId: string,
+    rowId: string,
+    entryId: string,
+    key: 'label' | 'value',
+    value: string,
+  ) => {
+    setSections(prev =>
+      prev.map(section => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+
+        return {
+          ...section,
+          rows: section.rows.map(row => {
+            if (row.id !== rowId) {
+              return row;
+            }
+
+            return {
+              ...row,
+              entries: row.entries.map(entry =>
+                entry.id === entryId ? { ...entry, [key]: value } : entry,
+              ),
+            };
+          }),
+        };
+      }),
+    );
+  };
+
+  const handleAddSection = () => {
+    setSections(prev => [
+      ...prev,
+      createSection('Новый раздел', [createRow('Новая строка', [createEntry('Поле', '')])]),
+    ]);
+  };
+
+  const handleRemoveSection = (sectionId: string) => {
+    setSections(prev => prev.filter(section => section.id !== sectionId));
+  };
+
+  const handleAddRow = (sectionId: string) => {
+    setSections(prev =>
+      prev.map(section =>
+        section.id === sectionId
+          ? {
+              ...section,
+              rows: [
+                ...section.rows,
+                createRow('Новая строка', [createEntry('S/N ядро'), createEntry('S/N производитель')]),
+              ],
+            }
+          : section,
+      ),
+    );
+  };
+
+  const handleRemoveRow = (sectionId: string, rowId: string) => {
+    setSections(prev =>
+      prev.map(section =>
+        section.id === sectionId
+          ? { ...section, rows: section.rows.filter(row => row.id !== rowId) }
+          : section,
+      ),
+    );
+  };
+
+  const handleAddEntry = (sectionId: string, rowId: string) => {
+    setSections(prev =>
+      prev.map(section => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+
+        return {
+          ...section,
+          rows: section.rows.map(row =>
+            row.id === rowId
+              ? {
+                  ...row,
+                  entries: [...row.entries, createEntry('Новое поле')],
+                }
+              : row,
+          ),
+        };
+      }),
+    );
+  };
+
+  const handleRemoveEntry = (sectionId: string, rowId: string, entryId: string) => {
+    setSections(prev =>
+      prev.map(section => {
+        if (section.id !== sectionId) {
+          return section;
+        }
+
+        return {
+          ...section,
+          rows: section.rows.map(row =>
+            row.id === rowId
+              ? { ...row, entries: row.entries.filter(entry => entry.id !== entryId) }
+              : row,
+          ),
+        };
+      }),
+    );
+  };
+
+  const handleResetTemplate = () => {
+    setSections(structureToSections(defaultTemplate.structure));
+    setSelectedTemplateId(DEFAULT_TEMPLATE_ID);
+    setActiveTemplateId(DEFAULT_TEMPLATE_ID);
+    setFeedbackMessage('Шаблон сервера применён');
+  };
+
+  const handleCopyStructure = async () => {
+    const json = JSON.stringify(serializableStructure, null, 2);
+
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(json);
+        setFeedbackMessage('Структура скопирована в буфер обмена');
+      } else {
+        throw new Error('Clipboard API unavailable');
+      }
+    } catch (error) {
+      console.error(error);
+      setFeedbackMessage('Не удалось скопировать структуру');
+    }
+  };
+
+  const handleApplyTemplate = (templateId?: string) => {
+    const id = templateId ?? selectedTemplateId;
+    const template = templates.find(item => item.id === id);
+    if (!template) {
+      return;
+    }
+
+    setSections(structureToSections(template.structure));
+    setSelectedTemplateId(template.id);
+    setActiveTemplateId(template.id);
+    setFeedbackMessage(`Шаблон «${template.name}» применён`);
+  };
+
+  const handleTemplateChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedTemplateId(event.target.value);
+  };
+
+  const handleSaveTemplate = () => {
+    const activeTemplate = templates.find(template => template.id === activeTemplateId);
+    const suggestedName =
+      activeTemplate && activeTemplate.id !== DEFAULT_TEMPLATE_ID ? activeTemplate.name : 'Новый шаблон';
+
+    const nameInput = window.prompt('Введите название шаблона', suggestedName);
+    const trimmedName = nameInput?.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    if (activeTemplate && activeTemplate.id !== DEFAULT_TEMPLATE_ID) {
+      setTemplates(prev =>
+        prev.map(template =>
+          template.id === activeTemplate.id
+            ? { ...template, name: trimmedName, structure: serializableStructure }
+            : template,
+        ),
+      );
+      setFeedbackMessage(`Шаблон «${trimmedName}» обновлён`);
+      return;
+    }
+
+    const newTemplate: PassportTemplate = {
+      id: `custom-${Date.now()}`,
+      name: trimmedName,
+      structure: serializableStructure,
+    };
+
+    setTemplates(prev => [...prev, newTemplate]);
+    setSections(structureToSections(newTemplate.structure));
+    setSelectedTemplateId(newTemplate.id);
+    setActiveTemplateId(newTemplate.id);
+    setFeedbackMessage(`Шаблон «${trimmedName}» сохранён`);
+  };
+
+  const handleCreateTemplate = () => {
+    const nameInput = window.prompt('Введите название нового шаблона', 'Новый шаблон');
+    const trimmedName = nameInput?.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    const structure = createEmptyTemplateStructure();
+    const template: PassportTemplate = {
+      id: `custom-${Date.now()}`,
+      name: trimmedName,
+      structure,
+    };
+
+    setTemplates(prev => [...prev, template]);
+    setSections(structureToSections(template.structure));
+    setSelectedTemplateId(template.id);
+    setActiveTemplateId(template.id);
+    setFeedbackMessage(`Создан шаблон «${trimmedName}»`);
+  };
+
+  const escapeForHtml = (value: string) =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const handleExportExcel = () => {
+    const rows: string[] = [];
+
+    serializableStructure.forEach(section => {
+      rows.push(`<tr class="section-row"><th colspan="3">${escapeForHtml(section.title || 'Без названия')}</th></tr>`);
+
+      if (!section.rows.length) {
+        rows.push('<tr><td colspan="3">Нет данных</td></tr>');
+        return;
+      }
+
+      section.rows.forEach(row => {
+        if (!row.entries.length) {
+          rows.push(
+            `<tr><td>${escapeForHtml(row.name || '')}</td><td colspan="2">—</td></tr>`,
+          );
+          return;
+        }
+
+        row.entries.forEach((entry, index) => {
+          const nameCell = index === 0 ? escapeForHtml(row.name || '') : '';
+          rows.push(
+            `<tr><td>${nameCell}</td><td>${escapeForHtml(entry.label)}</td><td>${escapeForHtml(entry.value)}</td></tr>`,
+          );
+        });
+      });
+    });
+
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><table>${rows.join(
+      '',
+    )}</table></body></html>`;
+    const blob = new Blob([html], { type: 'application/vnd.ms-excel' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'passport.xls';
+    link.click();
+    URL.revokeObjectURL(url);
+    setFeedbackMessage('Паспорт сохранён в Excel');
+  };
+
+  return (
+    <section className="passport-constructor">
+      <header className="passport-constructor__header">
+        <div>
+          <h2>Конструктор паспорта изделия</h2>
+          <p className="muted">
+            Соберите собственный шаблон паспорта для серверов, сетевого и другого оборудования.
+          </p>
+        </div>
+        <div className="passport-constructor__actions">
+          <button type="button" onClick={handleExportExcel}>
+            Сохранить в Excel
+          </button>
+          <button type="button" className="secondary" onClick={handleSaveTemplate}>
+            Сохранить шаблон
+          </button>
+          <button type="button" className="ghost" onClick={handleCreateTemplate}>
+            Создать новый шаблон
+          </button>
+          <button type="button" className="secondary" onClick={() => handleApplyTemplate()}>
+            Быстро выбрать шаблон
+          </button>
+          <button type="button" className="secondary" onClick={handleResetTemplate}>
+            Вернуть шаблон сервера
+          </button>
+          <button type="button" className="ghost" onClick={handleCopyStructure}>
+            Скопировать структуру JSON
+          </button>
+        </div>
+      </header>
+
+      <div className="passport-constructor__template-bar">
+        <label htmlFor="passport-template-select" className="passport-constructor__template-label">
+          Выберите шаблон изделия
+        </label>
+        <select
+          id="passport-template-select"
+          className="passport-constructor__template-select"
+          value={selectedTemplateId}
+          onChange={handleTemplateChange}
+        >
+          {templates.map(template => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="passport-constructor__content">
+        <div className="passport-constructor__editor">
+          {sections.map(section => (
+            <article key={section.id} className="passport-section">
+              <div className="passport-section__header">
+                <input
+                  value={section.title}
+                  onChange={event => handleSectionTitleChange(section.id, event.target.value)}
+                  className="passport-section__title"
+                  placeholder="Название раздела"
+                />
+                <div className="passport-section__controls">
+                  <button type="button" className="ghost" onClick={() => handleAddRow(section.id)}>
+                    Добавить строку
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => handleRemoveSection(section.id)}
+                  >
+                    Удалить раздел
+                  </button>
+                </div>
+              </div>
+
+              {section.rows.map(row => (
+                <div key={row.id} className="passport-row-editor">
+                  <input
+                    value={row.name}
+                    onChange={event => handleRowNameChange(section.id, row.id, event.target.value)}
+                    className="passport-row-editor__name"
+                    placeholder="Описание компонента"
+                  />
+                  <div className="passport-row-editor__entries">
+                    {row.entries.map(entry => (
+                      <div key={entry.id} className="passport-entry-editor">
+                        <input
+                          value={entry.label}
+                          onChange={event =>
+                            handleEntryChange(section.id, row.id, entry.id, 'label', event.target.value)
+                          }
+                          placeholder="Подпись поля"
+                        />
+                        <input
+                          value={entry.value}
+                          onChange={event =>
+                            handleEntryChange(section.id, row.id, entry.id, 'value', event.target.value)
+                          }
+                          placeholder="Значение"
+                        />
+                        <button
+                          type="button"
+                          className="ghost"
+                          onClick={() => handleRemoveEntry(section.id, row.id, entry.id)}
+                          aria-label="Удалить поле"
+                        >
+                          Удалить
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="passport-row-editor__controls">
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={() => handleAddEntry(section.id, row.id)}
+                    >
+                      Добавить поле
+                    </button>
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={() => handleRemoveRow(section.id, row.id)}
+                    >
+                      Удалить строку
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </article>
+          ))}
+
+          <button type="button" className="ghost" onClick={handleAddSection}>
+            Добавить раздел
+          </button>
+        </div>
+
+        <aside className="passport-constructor__preview">
+          <h3>Предпросмотр паспорта</h3>
+          <div className="passport-preview" role="presentation">
+            {sections.length === 0 ? (
+              <div className="preview-placeholder">
+                <p className="muted">Добавьте разделы, чтобы увидеть структуру паспорта.</p>
+              </div>
+            ) : (
+              sections.map(section => (
+                <div key={`${section.id}-preview`} className="passport-preview__section">
+                  <h4>{section.title || 'Без названия'}</h4>
+                  {section.rows.length === 0 ? (
+                    <p className="muted">Нет строк в разделе.</p>
+                  ) : (
+                    section.rows.map(row => (
+                      <div key={`${row.id}-preview`} className="passport-preview__row">
+                        <span className="passport-preview__row-name">{row.name || 'Новая строка'}</span>
+                        <div className="passport-preview__entries">
+                          {row.entries.length === 0 ? (
+                            <span className="muted">Нет полей</span>
+                          ) : (
+                            row.entries.map(entry => (
+                              <div key={`${entry.id}-preview`} className="passport-preview__entry">
+                                {entry.label ? (
+                                  <span className="passport-preview__entry-label">{entry.label}</span>
+                                ) : null}
+                                <span className="passport-preview__entry-value">
+                                  {entry.value ? entry.value : '—'}
+                                </span>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+          <pre className="passport-preview__json" aria-label="Структура паспорта в формате JSON">
+            {JSON.stringify(serializableStructure, null, 2)}
+          </pre>
+        </aside>
+      </div>
+
+      {feedbackMessage ? <p className="passport-constructor__status muted">{feedbackMessage}</p> : null}
+    </section>
+  );
+};
+

--- a/src/features/product-passport/ProductPassportContext.tsx
+++ b/src/features/product-passport/ProductPassportContext.tsx
@@ -1,0 +1,649 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { SerializableSection, createDefaultTemplate } from './passportSchema';
+
+export type DeviceAction =
+  | 'inspection'
+  | 'testing'
+  | 'repair'
+  | 'deployment'
+  | 'decommissioned'
+  | 'handover'
+  | 'rejected';
+
+export interface DeviceHistoryItem {
+  id: string;
+  date: string;
+  employee: string;
+  action: DeviceAction;
+  notes?: string;
+}
+
+export type InventoryStatus = 'in-use' | 'testing' | 'decommissioned';
+
+export interface InventoryDevice {
+  id: string;
+  assetTag: string;
+  modelId: string;
+  modelName: string;
+  serialNumber: string;
+  ipAddress: string;
+  location: string;
+  owner: string;
+  status: InventoryStatus;
+  warrantyUntil?: string;
+  lastUpdated: string;
+  history: DeviceHistoryItem[];
+}
+
+export interface ProductPassportModel {
+  id: string;
+  name: string;
+  vendor: string;
+  formFactor: string;
+  templateId: string;
+  templateStructure: SerializableSection[];
+  defaultPassportFields: Partial<Record<'assetTag' | 'model' | 'serialNumber' | 'location' | 'owner' | 'warrantyUntil' | 'ipAddress', string>>;
+  description?: string;
+}
+
+export interface PendingTemplateRequest {
+  templateId: string;
+  templateName: string;
+  structure: SerializableSection[];
+  source: 'inventory' | 'model' | 'new-device';
+  defaultFields?: Record<string, string>;
+  meta?: {
+    modelId?: string;
+    assetTag?: string;
+    ipAddress?: string;
+    serialNumber?: string;
+  };
+}
+
+interface CreateModelInput {
+  name: string;
+  vendor: string;
+  formFactor: string;
+  baseTemplate: 'server' | 'switch' | 'firewall';
+  defaultOwner?: string;
+  defaultLocation?: string;
+  defaultWarranty?: string;
+  defaultIpAddress?: string;
+  description?: string;
+}
+
+interface CreateDeviceInput {
+  modelId: string;
+  assetTag?: string;
+  serialNumber?: string;
+  ipAddress?: string;
+  location?: string;
+  owner?: string;
+  warrantyUntil?: string;
+  status?: InventoryStatus;
+  registeredBy?: string;
+}
+
+interface ProductPassportContextValue {
+  inventory: InventoryDevice[];
+  updateInventoryOwner: (id: string, owner: string, employee: string) => void;
+  findDevices: (query: string) => InventoryDevice[];
+  models: ProductPassportModel[];
+  createModel: (input: CreateModelInput) => ProductPassportModel;
+  createDevice: (input: CreateDeviceInput) => InventoryDevice | null;
+  applyModelTemplate: (
+    modelId: string,
+    options?: {
+      source?: PendingTemplateRequest['source'];
+      defaultFields?: Record<string, string | undefined>;
+      meta?: PendingTemplateRequest['meta'];
+    },
+  ) => PendingTemplateRequest | null;
+  pendingTemplate: PendingTemplateRequest | null;
+  clearPendingTemplate: () => void;
+}
+
+const ProductPassportContext = createContext<ProductPassportContextValue | null>(null);
+
+const cloneStructure = (structure: SerializableSection[]): SerializableSection[] =>
+  structure.map(section => ({
+    title: section.title,
+    rows: section.rows.map(row => ({
+      name: row.name,
+      entries: row.entries.map(entry => ({ label: entry.label, value: entry.value })),
+    })),
+  }));
+
+const rackServerStructure = createDefaultTemplate().structure;
+
+const networkSwitchStructure: SerializableSection[] = [
+  {
+    title: 'Основные сведения',
+    rows: [
+      {
+        name: 'Коммутатор',
+        entries: [
+          { label: 'Модель', value: 'Cisco Catalyst C9500-24Y4C' },
+          { label: 'Серийный номер', value: '' },
+        ],
+      },
+      {
+        name: 'Расположение',
+        entries: [
+          { label: 'Стойка', value: 'DC-West / Rack 42' },
+          { label: 'IP-адрес управления', value: '10.24.42.10' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Порты uplink',
+    rows: [
+      {
+        name: 'QSFP28-1',
+        entries: [
+          { label: 'Назначение', value: 'Магистраль в Spine' },
+          { label: 'Состояние', value: 'Активен' },
+        ],
+      },
+      {
+        name: 'QSFP28-2',
+        entries: [
+          { label: 'Назначение', value: 'Дублирующий uplink' },
+          { label: 'Состояние', value: 'Резерв' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'ПО и лицензии',
+    rows: [
+      {
+        name: 'Обновления',
+        entries: [
+          { label: 'Версия IOS-XE', value: '17.9.3a' },
+          { label: 'Дата последнего обновления', value: '2024-04-12' },
+        ],
+      },
+      {
+        name: 'Лицензии',
+        entries: [
+          { label: 'DNA Advantage', value: 'Активно до 2026-05-01' },
+          { label: 'Network Advantage', value: 'Активно до 2026-05-01' },
+        ],
+      },
+    ],
+  },
+];
+
+const firewallStructure: SerializableSection[] = [
+  {
+    title: 'Общее состояние',
+    rows: [
+      {
+        name: 'Устройство',
+        entries: [
+          { label: 'Модель', value: 'Fortinet FortiGate 1800F' },
+          { label: 'Серийный номер', value: '' },
+        ],
+      },
+      {
+        name: 'Сеть',
+        entries: [
+          { label: 'WAN IP', value: '203.0.113.18' },
+          { label: 'LAN IP', value: '10.10.10.1' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Модули и слоты',
+    rows: [
+      {
+        name: 'Слот 1',
+        entries: [
+          { label: 'Тип', value: 'NP6XLite' },
+          { label: 'Статус', value: 'Активен' },
+        ],
+      },
+      {
+        name: 'Слот 2',
+        entries: [
+          { label: 'Тип', value: 'NP7' },
+          { label: 'Статус', value: 'Готов' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Журналы и тесты',
+    rows: [
+      {
+        name: 'Последнее тестирование',
+        entries: [
+          { label: 'Дата', value: '2024-03-18' },
+          { label: 'Ответственный', value: 'Савельев Константин' },
+        ],
+      },
+      {
+        name: 'Примечания',
+        entries: [
+          { label: 'Результат', value: 'Ограничений не выявлено' },
+          { label: 'Браковка', value: 'Нет' },
+        ],
+      },
+    ],
+  },
+];
+
+const initialModels: ProductPassportModel[] = [
+  {
+    id: 'model-neytech-rack-2u',
+    name: 'Сервер NeyTech 2U',
+    vendor: 'NeyTech',
+    formFactor: 'Стоечный 2U',
+    templateId: 'template-neytech-rack-2u',
+    templateStructure: cloneStructure(rackServerStructure),
+    defaultPassportFields: {
+      model: 'NeyTech RackServer 2U',
+      owner: 'Команда платформы',
+      location: 'DC-East / Rack 18',
+      warrantyUntil: '2025-12-31',
+    },
+    description: 'Предустановленный шаблон паспорта для серверных конфигураций NeyTech.',
+  },
+  {
+    id: 'model-cisco-c9500',
+    name: 'Коммутатор Cisco C9500',
+    vendor: 'Cisco',
+    formFactor: 'Стоечный 1U',
+    templateId: 'template-cisco-c9500',
+    templateStructure: cloneStructure(networkSwitchStructure),
+    defaultPassportFields: {
+      model: 'Cisco Catalyst C9500-24Y4C',
+      owner: 'Команда сетей',
+      location: 'DC-West / Rack 42',
+      warrantyUntil: '2026-07-01',
+      ipAddress: '10.24.42.10',
+    },
+    description: 'Шаблон паспорта для магистральных коммутаторов Cisco с учётом uplink-портов и лицензий.',
+  },
+  {
+    id: 'model-fortinet-1800f',
+    name: 'Межсетевой экран Fortinet 1800F',
+    vendor: 'Fortinet',
+    formFactor: 'Стоечный 2U',
+    templateId: 'template-fortinet-1800f',
+    templateStructure: cloneStructure(firewallStructure),
+    defaultPassportFields: {
+      model: 'Fortinet FortiGate 1800F',
+      owner: 'Группа безопасности',
+      location: 'DC-West / Сектор Security',
+      warrantyUntil: '2025-11-15',
+      ipAddress: '203.0.113.18',
+    },
+    description: 'Включает разделы по слотам, проверке логов и документированию тестов безопасности.',
+  },
+];
+
+const nowIso = () => new Date().toISOString();
+const today = () => nowIso().slice(0, 10);
+
+const initialInventory: InventoryDevice[] = [
+  {
+    id: 'asset-0001',
+    assetTag: 'AST-1001',
+    modelId: 'model-cisco-c9500',
+    modelName: 'Коммутатор Cisco C9500',
+    serialNumber: 'SN123456789',
+    ipAddress: '10.24.42.11',
+    location: 'DC-West / Rack 42',
+    owner: 'Команда сетей',
+    status: 'in-use',
+    warrantyUntil: '2026-07-01',
+    lastUpdated: '2024-04-22',
+    history: [
+      {
+        id: 'hist-0001',
+        date: '2024-04-12',
+        employee: 'Иванов Сергей',
+        action: 'testing',
+        notes: 'Проверка новой версии IOS-XE',
+      },
+      {
+        id: 'hist-0002',
+        date: '2024-03-02',
+        employee: 'Петров Антон',
+        action: 'inspection',
+        notes: 'Ввод в эксплуатацию',
+      },
+    ],
+  },
+  {
+    id: 'asset-0002',
+    assetTag: 'AST-1058',
+    modelId: 'model-cisco-c9500',
+    modelName: 'Коммутатор Cisco C9500',
+    serialNumber: 'SN123456995',
+    ipAddress: '10.24.42.58',
+    location: 'DC-West / Rack 40',
+    owner: 'Команда сетей',
+    status: 'testing',
+    warrantyUntil: '2026-05-21',
+    lastUpdated: '2024-04-18',
+    history: [
+      {
+        id: 'hist-0003',
+        date: '2024-04-18',
+        employee: 'Смирнова Лидия',
+        action: 'testing',
+        notes: 'Тестирование резервного канала',
+      },
+      {
+        id: 'hist-0004',
+        date: '2024-02-11',
+        employee: 'Кузнецов Олег',
+        action: 'inspection',
+        notes: 'Диагностика перед развертыванием',
+      },
+    ],
+  },
+  {
+    id: 'asset-0003',
+    assetTag: 'AST-2010',
+    modelId: 'model-neytech-rack-2u',
+    modelName: 'Сервер NeyTech 2U',
+    serialNumber: 'NT-020524027B',
+    ipAddress: '10.60.20.5',
+    location: 'DC-East / Rack 18',
+    owner: 'Команда платформы',
+    status: 'in-use',
+    warrantyUntil: '2025-12-31',
+    lastUpdated: '2024-02-15',
+    history: [
+      {
+        id: 'hist-0005',
+        date: '2024-02-05',
+        employee: 'Честнов Алексей',
+        action: 'inspection',
+        notes: 'Входной контроль, проверка комплектации',
+      },
+      {
+        id: 'hist-0006',
+        date: '2024-02-06',
+        employee: 'Болышев Никита',
+        action: 'deployment',
+        notes: 'Сборка и ввод в эксплуатацию',
+      },
+    ],
+  },
+  {
+    id: 'asset-0004',
+    assetTag: 'AST-3301',
+    modelId: 'model-fortinet-1800f',
+    modelName: 'Межсетевой экран Fortinet 1800F',
+    serialNumber: 'FG1K4D3A21000001',
+    ipAddress: '203.0.113.18',
+    location: 'DC-West / Сектор Security',
+    owner: 'Группа безопасности',
+    status: 'in-use',
+    warrantyUntil: '2025-11-15',
+    lastUpdated: '2024-03-18',
+    history: [
+      {
+        id: 'hist-0007',
+        date: '2024-03-18',
+        employee: 'Савельев Константин',
+        action: 'testing',
+        notes: 'Проверка пропускной способности под нагрузкой',
+      },
+      {
+        id: 'hist-0008',
+        date: '2024-01-28',
+        employee: 'Исаева Наталья',
+        action: 'inspection',
+        notes: 'Контроль после сервисного окна',
+      },
+    ],
+  },
+];
+
+const generateSerial = () => `SN${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+
+const generateIp = (seed: number) => {
+  const thirdOctet = 40 + (seed % 40);
+  const fourthOctet = 10 + ((seed * 7) % 200);
+  return `10.${thirdOctet}.${fourthOctet}.${(seed % 180) + 5}`;
+};
+
+export const ProductPassportProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [models, setModels] = useState<ProductPassportModel[]>(initialModels);
+  const [inventory, setInventory] = useState<InventoryDevice[]>(initialInventory);
+  const [pendingTemplate, setPendingTemplate] = useState<PendingTemplateRequest | null>(null);
+
+  const assetCounter = useRef(initialInventory.length + 1000);
+  const serialCounter = useRef(initialInventory.length + 5000);
+
+  const updateInventoryOwner = useCallback((id: string, owner: string, employee: string) => {
+    setInventory(current =>
+      current.map(device => {
+        if (device.id !== id) {
+          return device;
+        }
+
+        const historyEntry: DeviceHistoryItem = {
+          id: `hist-${id}-${device.history.length + 1}`,
+          date: today(),
+          employee,
+          action: 'handover',
+          notes: `Назначен новый ответственный: ${owner}`,
+        };
+
+        return {
+          ...device,
+          owner,
+          lastUpdated: today(),
+          history: [historyEntry, ...device.history],
+        };
+      }),
+    );
+  }, []);
+
+  const findDevices = useCallback(
+    (query: string) => {
+      const value = query.trim().toLowerCase();
+      if (!value) {
+        return [];
+      }
+
+      return inventory.filter(device => {
+        const haystack = [
+          device.assetTag,
+          device.serialNumber,
+          device.modelName,
+          device.ipAddress,
+          device.owner,
+        ]
+          .filter(Boolean)
+          .map(item => item.toLowerCase());
+
+        return haystack.some(item => item.includes(value));
+      });
+    },
+    [inventory],
+  );
+
+  const createModel = useCallback(
+    (input: CreateModelInput): ProductPassportModel => {
+      const structure =
+        input.baseTemplate === 'server'
+          ? cloneStructure(rackServerStructure)
+          : input.baseTemplate === 'switch'
+          ? cloneStructure(networkSwitchStructure)
+          : cloneStructure(firewallStructure);
+
+      const id = `model-${Math.random().toString(36).slice(2, 10)}`;
+      const templateId = `template-${id}`;
+
+      const model: ProductPassportModel = {
+        id,
+        name: input.name,
+        vendor: input.vendor,
+        formFactor: input.formFactor,
+        templateId,
+        templateStructure: structure,
+        defaultPassportFields: {
+          model: input.name,
+          owner: input.defaultOwner,
+          location: input.defaultLocation,
+          warrantyUntil: input.defaultWarranty,
+          ipAddress: input.defaultIpAddress,
+        },
+        description: input.description,
+      };
+
+      setModels(current => [...current, model]);
+      return model;
+    },
+    [],
+  );
+
+  const createDevice = useCallback(
+    (input: CreateDeviceInput): InventoryDevice | null => {
+      const model = models.find(item => item.id === input.modelId);
+      if (!model) {
+        return null;
+      }
+
+      assetCounter.current += 1;
+      serialCounter.current += 1;
+
+      const generatedAssetTag = `AST-${assetCounter.current}`;
+      const assetTag = input.assetTag?.trim() || generatedAssetTag;
+      const serialNumber = input.serialNumber?.trim() || generateSerial();
+      const ipAddress = input.ipAddress?.trim() || generateIp(serialCounter.current);
+      const location = input.location?.trim() || model.defaultPassportFields.location || 'DC-West / Резерв';
+      const owner = input.owner?.trim() || model.defaultPassportFields.owner || 'Команда сетей';
+      const warrantyUntil = input.warrantyUntil || model.defaultPassportFields.warrantyUntil;
+      const status = input.status ?? 'testing';
+
+      const newDevice: InventoryDevice = {
+        id: `asset-${assetCounter.current}`,
+        assetTag,
+        modelId: model.id,
+        modelName: model.name,
+        serialNumber,
+        ipAddress,
+        location,
+        owner,
+        status,
+        warrantyUntil,
+        lastUpdated: today(),
+        history: [
+          {
+            id: `hist-${assetCounter.current}-0`,
+            date: today(),
+            employee: input.registeredBy || 'Система',
+            action: 'inspection',
+            notes: 'Изделие создано через мастер паспорта',
+          },
+        ],
+      };
+
+      setInventory(current => [newDevice, ...current]);
+      return newDevice;
+    },
+    [models],
+  );
+
+  const applyModelTemplate = useCallback(
+    (
+      modelId: string,
+      options?: {
+        source?: PendingTemplateRequest['source'];
+        defaultFields?: Record<string, string | undefined>;
+        meta?: PendingTemplateRequest['meta'];
+      },
+    ): PendingTemplateRequest | null => {
+      const model = models.find(item => item.id === modelId);
+      if (!model) {
+        return null;
+      }
+
+      const defaultFieldsEntries = {
+        model: model.name,
+        ...model.defaultPassportFields,
+        ...(options?.defaultFields ?? {}),
+      };
+
+      const normalizedFields = Object.entries(defaultFieldsEntries)
+        .filter(([, value]) => typeof value === 'string' && value.trim().length > 0)
+        .reduce<Record<string, string>>((accumulator, [key, value]) => {
+          accumulator[key] = value as string;
+          return accumulator;
+        }, {});
+
+      const request: PendingTemplateRequest = {
+        templateId: model.templateId,
+        templateName: model.name,
+        structure: cloneStructure(model.templateStructure),
+        source: options?.source ?? 'model',
+        defaultFields: normalizedFields,
+        meta: {
+          modelId: model.id,
+          ...options?.meta,
+        },
+      };
+
+      setPendingTemplate(request);
+      return request;
+    },
+    [models],
+  );
+
+  const clearPendingTemplate = useCallback(() => setPendingTemplate(null), []);
+
+  const contextValue = useMemo<ProductPassportContextValue>(
+    () => ({
+      inventory,
+      updateInventoryOwner,
+      findDevices,
+      models,
+      createModel,
+      createDevice,
+      applyModelTemplate,
+      pendingTemplate,
+      clearPendingTemplate,
+    }),
+    [
+      inventory,
+      updateInventoryOwner,
+      findDevices,
+      models,
+      createModel,
+      createDevice,
+      applyModelTemplate,
+      pendingTemplate,
+      clearPendingTemplate,
+    ],
+  );
+
+  return <ProductPassportContext.Provider value={contextValue}>{children}</ProductPassportContext.Provider>;
+};
+
+export const useProductPassport = (): ProductPassportContextValue => {
+  const context = useContext(ProductPassportContext);
+  if (!context) {
+    throw new Error('useProductPassport должен использоваться внутри ProductPassportProvider');
+  }
+
+  return context;
+};

--- a/src/features/product-passport/ProductPassportWizard.tsx
+++ b/src/features/product-passport/ProductPassportWizard.tsx
@@ -1,65 +1,400 @@
-import React, { useId } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
+
+import {
+  type DeviceAction,
+  type InventoryDevice,
+  type ProductPassportModel,
+  useProductPassport,
+} from './ProductPassportContext';
 
 export interface ProductPassportForm {
   assetTag: string;
   model: string;
   serialNumber: string;
+  ipAddress: string;
   location: string;
   owner: string;
   warrantyUntil?: string;
 }
 
-const steps = ['Lookup device', 'Confirm metadata', 'Add details', 'Attach documents'];
+interface CreateDeviceForm {
+  modelId: string;
+  assetTag: string;
+  serialNumber: string;
+  ipAddress: string;
+  location: string;
+  owner: string;
+  warrantyUntil: string;
+  registeredBy: string;
+}
+
+interface CreateModelForm {
+  name: string;
+  vendor: string;
+  formFactor: string;
+  baseTemplate: 'switch' | 'server' | 'firewall';
+  defaultOwner: string;
+  defaultLocation: string;
+  defaultWarranty: string;
+  defaultIpAddress: string;
+  description: string;
+}
+
+const steps = ['Поиск устройства', 'Проверка метаданных', 'Добавление сведений', 'Приложение документов'];
+
+const baseTemplateOptions: Array<{
+  value: CreateModelForm['baseTemplate'];
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'switch',
+    label: 'Коммутатор',
+    description: 'Шаблон для магистральных и распределительных коммутаторов.',
+  },
+  {
+    value: 'server',
+    label: 'Сервер',
+    description: 'Расширенный паспорт для серверов с контролем комплектации.',
+  },
+  {
+    value: 'firewall',
+    label: 'Межсетевой экран',
+    description: 'Структура для устройств безопасности и проверки журналов.',
+  },
+];
+
+const actionLabels: Record<DeviceAction, string> = {
+  inspection: 'Входной контроль',
+  testing: 'Тестирование',
+  repair: 'Ремонт',
+  deployment: 'Ввод в эксплуатацию',
+  decommissioned: 'Вывод из эксплуатации',
+  handover: 'Передача ответственности',
+  rejected: 'Забраковано',
+};
+
+const formatDate = (value: string | undefined) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('ru-RU');
+};
 
 export const ProductPassportWizard: React.FC = () => {
-  const { control, handleSubmit } = useForm<ProductPassportForm>({
+  const idPrefix = useId();
+  const {
+    inventory,
+    models,
+    findDevices,
+    createDevice,
+    createModel,
+    applyModelTemplate,
+  } = useProductPassport();
+
+  const { control, handleSubmit, setValue } = useForm<ProductPassportForm>({
     defaultValues: {
       assetTag: '',
       model: '',
       serialNumber: '',
+      ipAddress: '',
       location: '',
       owner: '',
       warrantyUntil: '',
     },
   });
 
-  const idPrefix = useId();
-  const activeStepIndex = 2;
+  const createDeviceForm = useForm<CreateDeviceForm>({
+    defaultValues: {
+      modelId: models[0]?.id ?? '',
+      assetTag: '',
+      serialNumber: '',
+      ipAddress: '',
+      location: '',
+      owner: '',
+      warrantyUntil: '',
+      registeredBy: '',
+    },
+  });
 
-  const fieldConfigs: Array<{
-    name: keyof ProductPassportForm;
-    label: string;
-    placeholder?: string;
-    type?: string;
-    required?: boolean;
-  }> = [
-    { name: 'assetTag', label: 'Asset tag', placeholder: 'e.g. AST-1001', required: true },
-    { name: 'model', label: 'Model', placeholder: 'Cisco C9500', required: true },
-    { name: 'serialNumber', label: 'Serial number', placeholder: 'SN123456789', required: true },
-    { name: 'location', label: 'Location', placeholder: 'DC-West / Rack 42', required: true },
-    { name: 'owner', label: 'Owner', placeholder: 'Network Team', required: true },
-    { name: 'warrantyUntil', label: 'Warranty valid until', type: 'date' },
-  ];
+  const createModelForm = useForm<CreateModelForm>({
+    defaultValues: {
+      name: '',
+      vendor: '',
+      formFactor: '',
+      baseTemplate: 'switch',
+      defaultOwner: '',
+      defaultLocation: '',
+      defaultWarranty: '',
+      defaultIpAddress: '',
+      description: '',
+    },
+  });
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<InventoryDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'inventory' | 'models'>('inventory');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSearchResults(inventory.slice(0, 6));
+  }, [inventory]);
+
+  useEffect(() => {
+    if (!statusMessage) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setStatusMessage(null), 4200);
+    return () => window.clearTimeout(timeout);
+  }, [statusMessage]);
+
+  const selectedDevice = useMemo<InventoryDevice | null>(() => {
+    if (!selectedDeviceId) {
+      return null;
+    }
+
+    return inventory.find(device => device.id === selectedDeviceId) ?? null;
+  }, [inventory, selectedDeviceId]);
+
+  const fieldConfigs = useMemo(
+    () =>
+      [
+        {
+          name: 'assetTag' as const,
+          label: 'Инвентарный номер',
+          placeholder: 'Например, AST-1001',
+          required: true,
+        },
+        { name: 'model' as const, label: 'Модель', placeholder: 'Cisco C9500', required: true },
+        {
+          name: 'serialNumber' as const,
+          label: 'Серийный номер',
+          placeholder: 'SN123456789',
+          required: true,
+        },
+        {
+          name: 'ipAddress' as const,
+          label: 'IP-адрес',
+          placeholder: '10.24.42.11',
+        },
+        {
+          name: 'location' as const,
+          label: 'Расположение',
+          placeholder: 'DC-West / Стойка 42',
+          required: true,
+        },
+        {
+          name: 'owner' as const,
+          label: 'Ответственный',
+          placeholder: 'Команда сетей',
+          required: true,
+        },
+        { name: 'warrantyUntil' as const, label: 'Гарантия действует до', type: 'date' as const },
+      ],
+    [],
+  );
+
+  const setFormValues = useCallback(
+    (values: Partial<ProductPassportForm>) => {
+      (Object.entries(values) as Array<[keyof ProductPassportForm, string | undefined]>).forEach(
+        ([field, value]) => {
+          if (typeof value === 'string') {
+            setValue(field, value);
+          }
+        },
+      );
+    },
+    [setValue],
+  );
+
+  const handleDeviceSelect = useCallback(
+    (device: InventoryDevice) => {
+      setSelectedDeviceId(device.id);
+      const defaults: Partial<ProductPassportForm> = {
+        assetTag: device.assetTag,
+        model: device.modelName,
+        serialNumber: device.serialNumber,
+        ipAddress: device.ipAddress,
+        location: device.location,
+        owner: device.owner,
+        warrantyUntil: device.warrantyUntil ?? '',
+      };
+
+      setFormValues(defaults);
+
+      applyModelTemplate(device.modelId, {
+        source: 'inventory',
+        defaultFields: defaults,
+        meta: {
+          assetTag: device.assetTag,
+          serialNumber: device.serialNumber,
+          ipAddress: device.ipAddress,
+          modelId: device.modelId,
+        },
+      });
+
+      setStatusMessage(`Устройство ${device.assetTag} подставлено из инвентаря.`);
+    },
+    [applyModelTemplate, setFormValues],
+  );
+
+  const handleSearchDevices = useCallback(() => {
+    if (!searchQuery.trim()) {
+      setSearchResults(inventory.slice(0, 6));
+      return;
+    }
+
+    const results = findDevices(searchQuery);
+    setSearchResults(results);
+    if (results.length === 0) {
+      setStatusMessage('Подходящих устройств не найдено.');
+    }
+  }, [findDevices, inventory, searchQuery]);
+
+  const getLatestDeviceForModel = useCallback(
+    (modelId: string) =>
+      inventory
+        .filter(device => device.modelId === modelId)
+        .sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''))[0] ?? null,
+    [inventory],
+  );
+
+  const handleModelApply = useCallback(
+    (model: ProductPassportModel) => {
+      const latest = getLatestDeviceForModel(model.id);
+      const defaults: Partial<ProductPassportForm> = {
+        model: model.name,
+        owner: model.defaultPassportFields.owner ?? '',
+        location: model.defaultPassportFields.location ?? '',
+        warrantyUntil: model.defaultPassportFields.warrantyUntil ?? '',
+        ipAddress: model.defaultPassportFields.ipAddress ?? '',
+      };
+
+      if (latest) {
+        defaults.assetTag = latest.assetTag;
+        defaults.serialNumber = latest.serialNumber;
+        defaults.location = latest.location;
+        defaults.owner = latest.owner;
+        defaults.ipAddress = latest.ipAddress;
+        defaults.warrantyUntil = latest.warrantyUntil ?? defaults.warrantyUntil;
+      }
+
+      setFormValues(defaults);
+      if (latest) {
+        setSelectedDeviceId(latest.id);
+      }
+
+      applyModelTemplate(model.id, {
+        source: 'model',
+        defaultFields: defaults,
+        meta: {
+          modelId: model.id,
+          assetTag: defaults.assetTag,
+          serialNumber: defaults.serialNumber,
+          ipAddress: defaults.ipAddress,
+        },
+      });
+
+      setActiveTab('inventory');
+      setStatusMessage(
+        latest
+          ? `Шаблон модели «${model.name}» применён. Использовано устройство ${latest.assetTag}.`
+          : `Шаблон модели «${model.name}» применён.`,
+      );
+    },
+    [applyModelTemplate, getLatestDeviceForModel, setFormValues],
+  );
+
+  const onCreateDevice = createDeviceForm.handleSubmit(values => {
+    const device = createDevice({
+      modelId: values.modelId,
+      assetTag: values.assetTag,
+      serialNumber: values.serialNumber,
+      ipAddress: values.ipAddress,
+      location: values.location,
+      owner: values.owner,
+      warrantyUntil: values.warrantyUntil,
+      registeredBy: values.registeredBy,
+    });
+
+    if (!device) {
+      setStatusMessage('Не удалось создать изделие. Проверьте выбранную модель.');
+      return;
+    }
+
+    handleDeviceSelect(device);
+    setSearchResults(current => [device, ...current.filter(item => item.id !== device.id)].slice(0, 6));
+    setStatusMessage(`Изделие ${device.assetTag} создано и готово к заполнению паспорта.`);
+    setActiveTab('inventory');
+
+    createDeviceForm.reset({
+      modelId: values.modelId,
+      assetTag: '',
+      serialNumber: '',
+      ipAddress: '',
+      location: '',
+      owner: '',
+      warrantyUntil: '',
+      registeredBy: '',
+    });
+  });
+
+  const onCreateModel = createModelForm.handleSubmit(values => {
+    const model = createModel({
+      name: values.name,
+      vendor: values.vendor,
+      formFactor: values.formFactor,
+      baseTemplate: values.baseTemplate,
+      defaultOwner: values.defaultOwner,
+      defaultLocation: values.defaultLocation,
+      defaultWarranty: values.defaultWarranty,
+      defaultIpAddress: values.defaultIpAddress,
+      description: values.description,
+    });
+
+    setStatusMessage(`Модель «${model.name}» сохранена и доступна для подстановки.`);
+    createModelForm.reset({
+      name: '',
+      vendor: '',
+      formFactor: '',
+      baseTemplate: values.baseTemplate,
+      defaultOwner: '',
+      defaultLocation: '',
+      defaultWarranty: '',
+      defaultIpAddress: '',
+      description: '',
+    });
+  });
 
   const onSubmit = handleSubmit(data => {
-    // In a real app this would trigger generation of the product passport document.
     console.log('Generating product passport', data);
+    setStatusMessage('Черновик паспорта подготовлен.');
   });
 
   return (
     <section className="passport-wizard">
       <header className="passport-wizard__header">
         <div>
-          <h2>Product passport wizard</h2>
-          <p className="muted">Auto-populate fields from inventory and finalize a PDF passport.</p>
+          <h2>Мастер создания паспорта изделия</h2>
+          <p className="muted">Автоматически заполните данные из инвентаря и сформируйте PDF-паспорт.</p>
         </div>
-        <span className="status-badge status-online">Connected</span>
+        <span className="status-badge status-online">Подключено</span>
       </header>
+
+      {statusMessage && <div className="passport-wizard__status">{statusMessage}</div>}
+
       <ol className="wizard-steps">
         {steps.map((step, index) => {
-          const state =
-            index < activeStepIndex ? 'completed' : index === activeStepIndex ? 'active' : 'upcoming';
+          const state = index < 1 ? 'completed' : index === 1 ? 'active' : 'upcoming';
           return (
             <li key={step} className="wizard-step" data-state={state}>
               <span className="wizard-step__index">{index + 1}</span>
@@ -69,39 +404,294 @@ export const ProductPassportWizard: React.FC = () => {
         })}
       </ol>
 
-      <form className="passport-wizard__form" onSubmit={onSubmit}>
-        <div className="passport-wizard__grid">
-          {fieldConfigs.map(config => {
-            const inputId = `${idPrefix}-${config.name}`;
-            return (
-              <div key={config.name} className="form-field">
-                <label htmlFor={inputId}>{config.label}</label>
-                <Controller
-                  control={control}
-                  name={config.name}
-                  render={({ field }) => (
-                    <input
-                      {...field}
-                      id={inputId}
-                      type={config.type ?? 'text'}
-                      placeholder={config.placeholder}
-                      required={config.required}
-                    />
-                  )}
+      <div className="passport-wizard__layout">
+        <form className="passport-wizard__form" onSubmit={onSubmit}>
+          <div className="passport-wizard__grid">
+            {fieldConfigs.map(config => {
+              const inputId = `${idPrefix}-${config.name}`;
+              return (
+                <div key={config.name} className="form-field">
+                  <label htmlFor={inputId}>{config.label}</label>
+                  <Controller
+                    control={control}
+                    name={config.name}
+                    render={({ field }) => (
+                      <input
+                        {...field}
+                        id={inputId}
+                        type={config.type ?? 'text'}
+                        placeholder={config.placeholder}
+                        required={config.required}
+                      />
+                    )}
+                  />
+                </div>
+              );
+            })}
+          </div>
+          <footer className="passport-wizard__actions">
+            <button type="submit" className="primary">
+              Сформировать PDF-паспорт
+            </button>
+            <button type="button" className="secondary">
+              Экспортировать реестр в CSV
+            </button>
+          </footer>
+        </form>
+
+        <aside className="passport-wizard__sidebar">
+          <div className="passport-wizard__tabs" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              className={activeTab === 'inventory' ? 'active' : ''}
+              aria-selected={activeTab === 'inventory'}
+              onClick={() => setActiveTab('inventory')}
+            >
+              Инвентарь
+            </button>
+            <button
+              type="button"
+              role="tab"
+              className={activeTab === 'models' ? 'active' : ''}
+              aria-selected={activeTab === 'models'}
+              onClick={() => setActiveTab('models')}
+            >
+              Модели изделий
+            </button>
+          </div>
+
+          {activeTab === 'inventory' ? (
+            <div className="passport-wizard__inventory" role="tabpanel">
+              <div className="passport-wizard__search">
+                <input
+                  type="search"
+                  value={searchQuery}
+                  onChange={event => setSearchQuery(event.target.value)}
+                  placeholder="Введите инвентарный номер, IP или модель"
                 />
+                <button type="button" onClick={handleSearchDevices}>
+                  Найти устройство
+                </button>
               </div>
-            );
-          })}
-        </div>
-        <footer className="passport-wizard__actions">
-          <button type="submit" className="primary">
-            Generate PDF passport
-          </button>
-          <button type="button" className="secondary">
-            Export registry CSV
-          </button>
-        </footer>
-      </form>
+              <ul className="passport-wizard__results">
+                {searchResults.length === 0 ? (
+                  <li className="empty">Ничего не найдено</li>
+                ) : (
+                  searchResults.map(device => (
+                    <li key={device.id} data-active={device.id === selectedDeviceId}>
+                      <button type="button" onClick={() => handleDeviceSelect(device)}>
+                        <span className="asset">{device.assetTag}</span>
+                        <span className="model">{device.modelName}</span>
+                        <span className="ip">{device.ipAddress}</span>
+                      </button>
+                    </li>
+                  ))
+                )}
+              </ul>
+
+              {selectedDevice && (
+                <div className="passport-wizard__device-details">
+                  <h3>Данные устройства</h3>
+                  <dl>
+                    <div>
+                      <dt>Инвентарный номер</dt>
+                      <dd>{selectedDevice.assetTag}</dd>
+                    </div>
+                    <div>
+                      <dt>IP-адрес</dt>
+                      <dd>{selectedDevice.ipAddress || '—'}</dd>
+                    </div>
+                    <div>
+                      <dt>Расположение</dt>
+                      <dd>{selectedDevice.location}</dd>
+                    </div>
+                    <div>
+                      <dt>Ответственный</dt>
+                      <dd>{selectedDevice.owner}</dd>
+                    </div>
+                    <div>
+                      <dt>Гарантия</dt>
+                      <dd>{formatDate(selectedDevice.warrantyUntil)}</dd>
+                    </div>
+                  </dl>
+
+                  <h4>Последние действия</h4>
+                  <ul>
+                    {selectedDevice.history.slice(0, 4).map(entry => (
+                      <li key={entry.id}>
+                        <span className="date">{formatDate(entry.date)}</span>
+                        <span className="action">{actionLabels[entry.action]}</span>
+                        <span className="employee">{entry.employee}</span>
+                        {entry.notes && <span className="notes">{entry.notes}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <form className="passport-wizard__create" onSubmit={onCreateDevice}>
+                <h3>Создать изделие</h3>
+                <p className="muted">
+                  Выберите модель и заполните ключевые поля, чтобы добавить новую позицию в инвентарь и сразу начать
+                  паспорт.
+                </p>
+                <div className="form-field">
+                  <label htmlFor={`${idPrefix}-create-model`}>Модель</label>
+                  <select id={`${idPrefix}-create-model`} {...createDeviceForm.register('modelId')}>
+                    {models.map(model => (
+                      <option key={model.id} value={model.id}>
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    Инвентарный номер
+                    <input {...createDeviceForm.register('assetTag')} placeholder="AST-1200" />
+                  </label>
+                  <label>
+                    Серийный номер
+                    <input {...createDeviceForm.register('serialNumber')} placeholder="SN987654321" />
+                  </label>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    IP-адрес
+                    <input {...createDeviceForm.register('ipAddress')} placeholder="10.60.20.12" />
+                  </label>
+                  <label>
+                    Расположение
+                    <input {...createDeviceForm.register('location')} placeholder="DC-East / Rack 18" />
+                  </label>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    Ответственный
+                    <input {...createDeviceForm.register('owner')} placeholder="Команда сетей" />
+                  </label>
+                  <label>
+                    Гарантия до
+                    <input type="date" {...createDeviceForm.register('warrantyUntil')} />
+                  </label>
+                </div>
+                <div className="form-field">
+                  <label>
+                    Сотрудник
+                    <input {...createDeviceForm.register('registeredBy')} placeholder="Фамилия и инициалы" />
+                  </label>
+                </div>
+                <button type="submit" className="secondary">
+                  Создать изделие
+                </button>
+              </form>
+            </div>
+          ) : (
+            <div className="passport-wizard__models" role="tabpanel">
+              <div className="passport-wizard__model-list">
+                {models.map(model => {
+                  const latest = getLatestDeviceForModel(model.id);
+                  return (
+                    <article key={model.id} className="passport-wizard__model-card">
+                      <header>
+                        <h3>{model.name}</h3>
+                        <p className="muted">
+                          {model.vendor} · {model.formFactor}
+                        </p>
+                      </header>
+                      {model.description && <p>{model.description}</p>}
+                      <dl>
+                        <div>
+                          <dt>Ответственный</dt>
+                          <dd>{model.defaultPassportFields.owner ?? '—'}</dd>
+                        </div>
+                        <div>
+                          <dt>Расположение</dt>
+                          <dd>{model.defaultPassportFields.location ?? '—'}</dd>
+                        </div>
+                        <div>
+                          <dt>IP по умолчанию</dt>
+                          <dd>{model.defaultPassportFields.ipAddress ?? '—'}</dd>
+                        </div>
+                      </dl>
+                      {latest && (
+                        <p className="muted">
+                          Последняя работа: {latest.assetTag} · {formatDate(latest.lastUpdated)}
+                        </p>
+                      )}
+                      <footer>
+                        <button type="button" onClick={() => handleModelApply(model)}>
+                          Выбрать модель
+                        </button>
+                      </footer>
+                    </article>
+                  );
+                })}
+              </div>
+
+              <form className="passport-wizard__create-model" onSubmit={onCreateModel}>
+                <h3>Новый шаблон модели</h3>
+                <div className="form-field-grid">
+                  <label>
+                    Название
+                    <input {...createModelForm.register('name', { required: true })} placeholder="Коммутатор доступа" />
+                  </label>
+                  <label>
+                    Производитель
+                    <input {...createModelForm.register('vendor')} placeholder="Cisco" />
+                  </label>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    Форм-фактор
+                    <input {...createModelForm.register('formFactor')} placeholder="Стоечный 1U" />
+                  </label>
+                  <label>
+                    Базовый шаблон
+                    <select {...createModelForm.register('baseTemplate')}>
+                      {baseTemplateOptions.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    Ответственный
+                    <input {...createModelForm.register('defaultOwner')} placeholder="Команда сетей" />
+                  </label>
+                  <label>
+                    Расположение
+                    <input {...createModelForm.register('defaultLocation')} placeholder="DC-West / Rack 42" />
+                  </label>
+                </div>
+                <div className="form-field-grid">
+                  <label>
+                    IP по умолчанию
+                    <input {...createModelForm.register('defaultIpAddress')} placeholder="10.24.42.10" />
+                  </label>
+                  <label>
+                    Гарантия до
+                    <input type="date" {...createModelForm.register('defaultWarranty')} />
+                  </label>
+                </div>
+                <div className="form-field">
+                  <label>
+                    Описание
+                    <textarea {...createModelForm.register('description')} rows={3} placeholder="Примечания и область применения" />
+                  </label>
+                </div>
+                <button type="submit" className="secondary">
+                  Сохранить модель
+                </button>
+              </form>
+            </div>
+          )}
+        </aside>
+      </div>
     </section>
   );
 };

--- a/src/features/product-passport/passportSchema.ts
+++ b/src/features/product-passport/passportSchema.ts
@@ -1,0 +1,283 @@
+export interface PassportEntry {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface PassportRow {
+  id: string;
+  name: string;
+  entries: PassportEntry[];
+}
+
+export interface PassportSection {
+  id: string;
+  title: string;
+  rows: PassportRow[];
+}
+
+export interface SerializableEntry {
+  label: string;
+  value: string;
+}
+
+export interface SerializableRow {
+  name: string;
+  entries: SerializableEntry[];
+}
+
+export interface SerializableSection {
+  title: string;
+  rows: SerializableRow[];
+}
+
+export interface PassportTemplate {
+  id: string;
+  name: string;
+  structure: SerializableSection[];
+}
+
+const createId = (() => {
+  let counter = 0;
+  return (prefix = 'passport') => {
+    counter += 1;
+    return `${prefix}-${counter}`;
+  };
+})();
+
+export const createEntry = (label: string, value = ''): PassportEntry => ({
+  id: createId('entry'),
+  label,
+  value,
+});
+
+export const createRow = (name: string, entries: PassportEntry[]): PassportRow => ({
+  id: createId('row'),
+  name,
+  entries,
+});
+
+export const createSection = (title: string, rows: PassportRow[]): PassportSection => ({
+  id: createId('section'),
+  title,
+  rows,
+});
+
+export const sectionsToSerializable = (sections: PassportSection[]): SerializableSection[] =>
+  sections.map(section => ({
+    title: section.title,
+    rows: section.rows.map(row => ({
+      name: row.name,
+      entries: row.entries.map(entry => ({ label: entry.label, value: entry.value })),
+    })),
+  }));
+
+export const structureToSections = (structure: SerializableSection[]): PassportSection[] =>
+  structure.map(section =>
+    createSection(
+      section.title,
+      section.rows.map(row => createRow(row.name, row.entries.map(entry => createEntry(entry.label, entry.value)))),
+    ),
+  );
+
+export const createServerTemplateSections = (): PassportSection[] => [
+  createSection('Общие сведения', [
+    createRow('Наименование', [
+      createEntry('Тип/ревизия/производитель'),
+      createEntry('Серийный номер'),
+    ]),
+    createRow('Серийный № сервера', [createEntry('Значение', '020524027B')]),
+    createRow('Дата проведения входного контроля', [createEntry('Значение', '05.02.2024')]),
+    createRow('Фамилии сотрудников, проводивших проверку (с фото)', [
+      createEntry('Сотрудник 1', 'Честнов Алексей'),
+      createEntry('Сотрудник 2', 'Болышев Никита'),
+    ]),
+  ]),
+  createSection('HDD диски', [
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO7021'),
+      createEntry('S/N производитель', 'ZRT1QSF9'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO7020'),
+      createEntry('S/N производитель', 'ZRT1QSLH'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO701Z'),
+      createEntry('S/N производитель', 'ZRT1NEE3'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO703B'),
+      createEntry('S/N производитель', 'ZRT1RC7S'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO703O'),
+      createEntry('S/N производитель', 'ZRT1RD46'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO703C'),
+      createEntry('S/N производитель', 'ZV70H19V'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO7022'),
+      createEntry('S/N производитель', 'ZV70H19P'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO7023'),
+      createEntry('S/N производитель', 'ZV70HYGL'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO702O'),
+      createEntry('S/N производитель', 'ZV70HXTW'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO703A'),
+      createEntry('S/N производитель', 'ZV70HYEP'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'Y1P6A0GMO7039'),
+      createEntry('S/N производитель', 'ZRT1QTC2'),
+    ]),
+    createRow('Seagate STL015', [
+      createEntry('S/N ядро', 'P8CSWAP9LFDC5Y219GCT35HT8G3U6MY5'),
+      createEntry('S/N производитель', 'ZV70H0JY'),
+    ]),
+  ]),
+  createSection('Backplane HDD', [
+    createRow('BPLSAS780002C', [createEntry('S/N ядро', 'Y2GZC017PI01G')]),
+  ]),
+  createSection('Материнская плата', [
+    createRow('MBDX86780001E', [
+      createEntry('S/N ядро', 'Y1JOA302VA1VO'),
+      createEntry('Отметки', '1E-'),
+    ]),
+  ]),
+  createSection('Кулеры CPU', [createRow('Кулер', [createEntry('Тип', 'Тип 1')])]),
+  createSection('Блоки питания', [
+    createRow('ASP U1A-D11200-DRB', [
+      createEntry('S/N ядро', 'Y09OA0XDVR03Q'),
+      createEntry('S/N производитель', 'D041200K6B0241'),
+    ]),
+    createRow('ASP U1A-D11200-DRB', [
+      createEntry('S/N ядро', 'Y09OA0XDVR03P'),
+      createEntry('S/N производитель', 'D041200K6B0314'),
+    ]),
+  ]),
+  createSection('SSD накопители', [
+    createRow('Micron MTFDDAK960TDS', [
+      createEntry('S/N ядро', 'Y0IDA0KHTZ00W'),
+      createEntry('S/N производитель', '220534A667C3'),
+    ]),
+    createRow('Micron MTFDDAK960TDS', [
+      createEntry('S/N ядро', 'Y0IDA0KHTZ00V'),
+      createEntry('S/N производитель', '220534A667D6'),
+    ]),
+    createRow('Samsung MZ-WLR7T60', [
+      createEntry('S/N ядро', 'Y1DAA08O7B01S'),
+      createEntry('S/N производитель', 'S6EWNE0R708721'),
+    ]),
+    createRow('Samsung MZ-WLR7T60', [
+      createEntry('S/N ядро', 'Y1DAA08O7B01Q'),
+      createEntry('S/N производитель', 'S6EWNE0R708715'),
+    ]),
+  ]),
+  createSection('BMC', [
+    createRow('IOBBMC740001C', [createEntry('S/N ядро', 'Y0SOC01NEU0MD')]),
+  ]),
+  createSection('Backplane SSD', [
+    createRow('Модуль', [
+      createEntry('Разъём', '+'),
+      createEntry('S/N ядро', 'Y0UIE01A2U12F'),
+    ]),
+  ]),
+  createSection('Планки памяти', [
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313I'),
+      createEntry('S/N производитель', 'Y0S402031624B25747'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313G'),
+      createEntry('S/N производитель', 'Y0S402031624B25591'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313B'),
+      createEntry('S/N производитель', 'Y0S402031624B254EB'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A130NA'),
+      createEntry('S/N производитель', 'Y0NB49031524B0B943'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313L'),
+      createEntry('S/N производитель', 'Y0S402031624B25592'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313D'),
+      createEntry('S/N производитель', 'Y0S402031624B25518'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313E'),
+      createEntry('S/N производитель', 'Y0S402031624B25410'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313C'),
+      createEntry('S/N производитель', 'Y0S402031624B2552C'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313H'),
+      createEntry('S/N производитель', 'Y0S402031624B25507'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313K'),
+      createEntry('S/N производитель', 'Y0S402031624B255A1'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313F'),
+      createEntry('S/N производитель', 'Y0S402031624B25536'),
+    ]),
+    createRow('Samsung M393A8G40AB2-CWEС0', [
+      createEntry('S/N ядро', 'Y1YMA08A1313J'),
+      createEntry('S/N производитель', 'Y0S402031624B25559'),
+    ]),
+  ]),
+  createSection('RAID-контроллер', [
+    createRow('Тип 1', [
+      createEntry('S/N ядро', 'Y0TEA0ABK706B'),
+      createEntry(
+        'S/N производитель',
+        '03-50077-00004, SKC2211958, 500062B-220EE41100, 02-50077-50003, 9560-16i 8GB',
+      ),
+    ]),
+  ]),
+  createSection('Сетевая карта', [
+    createRow('Rev.20', [
+      createEntry('S/N ядро', 'Y01CA0AGAT0LT'),
+      createEntry('S/N производитель', 'A41422213001O1FV'),
+    ]),
+  ]),
+];
+
+export const DEFAULT_TEMPLATE_ID = 'passport-template-server';
+
+export const createDefaultTemplate = (): PassportTemplate => ({
+  id: DEFAULT_TEMPLATE_ID,
+  name: 'Серверное оборудование',
+  structure: sectionsToSerializable(createServerTemplateSections()),
+});
+
+export const createEmptyTemplateStructure = (): SerializableSection[] => [
+  {
+    title: 'Новый раздел',
+    rows: [
+      {
+        name: 'Новая строка',
+        entries: [
+          {
+            label: 'Поле',
+            value: '',
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/features/reports/ReportsBuilderCanvas.tsx
+++ b/src/features/reports/ReportsBuilderCanvas.tsx
@@ -3,7 +3,6 @@ import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const blockOptions = [
-
   'Обложка паспорта изделия',
   'Входной контроль и бригада',
   'HDD диски',
@@ -15,13 +14,6 @@ const blockOptions = [
 ] as const;
 
 const presetOptions = ['rack-server', 'blade-server', 'storage-node'] as const;
-
-  'Сводка KPI',
-  'Временной ряд',
-  'Таблица пропускной способности',
-  'Хронология инцидентов',
-] as const;
-
 
 type BlockOption = (typeof blockOptions)[number];
 type PresetOption = (typeof presetOptions)[number];
@@ -225,7 +217,6 @@ const presetLabels: Record<PresetOption, string> = {
 export const ReportsBuilderCanvas: React.FC = () => {
   const { control, handleSubmit, watch } = useForm<ReportsBuilderForm>({
     defaultValues: {
-
       name: 'Паспорт сервера №020524027B',
       preset: 'rack-server',
       blocks: [
@@ -238,11 +229,6 @@ export const ReportsBuilderCanvas: React.FC = () => {
         'Питание и охлаждение',
         'Контроллеры расширения',
       ],
-
-      name: 'Еженедельный обзор для руководства',
-      preset: 'week',
-      blocks: ['Сводка KPI'],
-
     },
   });
 
@@ -300,7 +286,6 @@ export const ReportsBuilderCanvas: React.FC = () => {
     <section className="reports-builder">
       <header className="reports-builder__header">
         <div>
-
           <h2>Конструктор паспорта изделия</h2>
           <p className="muted">
             Соберите структурированный паспорт серверного изделия: фиксируйте конфигурацию оборудования,
@@ -308,22 +293,12 @@ export const ReportsBuilderCanvas: React.FC = () => {
           </p>
         </div>
         <span className="status-badge status-active">Синхронизировано с CMDB</span>
-
-          <h2>Конструктор отчётов</h2>
-          <p className="muted">Создавайте макеты методом перетаскивания и экспортируйте их в PDF/CSV/XLSX.</p>
-        </div>
-        <span className="status-badge status-active">Предпросмотр в реальном времени</span>
-
       </header>
 
       <form className="reports-builder__form" onSubmit={onSubmit}>
         <div className="form-controls">
           <div className="form-field">
-
             <label htmlFor={`${idPrefix}-name`}>Название паспорта</label>
-
-            <label htmlFor={`${idPrefix}-name`}>Название отчёта</label>
-
             <Controller
               control={control}
               name="name"
@@ -331,11 +306,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
                 <input
                   {...field}
                   id={`${idPrefix}-name`}
-
                   placeholder="Паспорт изделия"
-
-                  placeholder="Сводка для руководства"
-
                   required
                 />
               )}
@@ -343,27 +314,17 @@ export const ReportsBuilderCanvas: React.FC = () => {
           </div>
 
           <div className="form-field">
-
             <label htmlFor={`${idPrefix}-preset`}>Тип конфигурации</label>
-
-            <label htmlFor={`${idPrefix}-preset`}>Предустановка</label>
-
             <Controller
               control={control}
               name="preset"
               render={({ field }) => (
                 <select {...field} id={`${idPrefix}-preset`}>
-
                   {presetOptions.map(option => (
                     <option key={option} value={option}>
                       {presetLabels[option]}
                     </option>
                   ))}
-
-                  <option value="day">День</option>
-                  <option value="week">Неделя</option>
-                  <option value="month">Месяц</option>
-
                 </select>
               )}
             />
@@ -371,11 +332,7 @@ export const ReportsBuilderCanvas: React.FC = () => {
         </div>
 
         <fieldset>
-
           <legend>Разделы паспорта</legend>
-
-          <legend>Блоки</legend>
-
           <Controller
             control={control}
             name="blocks"
@@ -425,7 +382,6 @@ export const ReportsBuilderCanvas: React.FC = () => {
                   strokeLinejoin="round"
                 />
               </svg>
-
               <p>Выберите разделы паспорта, чтобы увидеть структуру документа.</p>
             </div>
           ) : (
@@ -455,39 +411,12 @@ export const ReportsBuilderCanvas: React.FC = () => {
                   </article>
                 );
               })}
-
-              <p>Предпросмотр отчёта будет отображаться здесь</p>
-            </div>
-          ) : (
-            <div className="preview-grid">
-              {blocks.map(block => (
-                <article key={block} className="builder-block">
-                  <div className="builder-block__icon" aria-hidden>
-                    <svg viewBox="0 0 48 48">
-                      <rect x="6" y="10" width="36" height="28" rx="6" fill="rgba(148, 163, 184, 0.14)" />
-                      <path
-                        d="M12 30c4-6 8-10 12-10s8 4 12 10"
-                        stroke="rgba(51, 245, 255, 0.75)"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        fill="none"
-                      />
-                    </svg>
-                  </div>
-                  <div className="builder-block__body">
-                    <h3>{block}</h3>
-                    <p className="muted">Предпросмотр отчёта будет отображаться здесь</p>
-                  </div>
-                </article>
-              ))}
             </div>
           )}
         </div>
         <footer className="reports-builder__actions">
           <button type="submit" className="primary">
             <FormatIcon variant="pdf" />
-
             Сформировать PDF паспорт
           </button>
           <button type="button" className="secondary">
@@ -497,16 +426,6 @@ export const ReportsBuilderCanvas: React.FC = () => {
           <button type="button" className="ghost">
             <FormatIcon variant="xlsx" />
             Экспорт XLSX спецификации
-
-            Экспорт в PDF
-          </button>
-          <button type="button" className="secondary">
-            <FormatIcon variant="csv" />
-            Экспорт в CSV
-          </button>
-          <button type="button" className="ghost">
-            <FormatIcon variant="xlsx" />
-            Экспорт в XLSX
           </button>
         </footer>
       </form>

--- a/src/pages/product-passport/ProductPassportPage.tsx
+++ b/src/pages/product-passport/ProductPassportPage.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { ProductPassportWizard } from '../../features/product-passport/ProductPassportWizard';
+import { ProductPassportConstructor } from '../../features/product-passport/ProductPassportConstructor';
 
-const ProductPassportPage: React.FC = () => <ProductPassportWizard />;
+const ProductPassportPage: React.FC = () => (
+  <div className="stacked-page">
+    <ProductPassportWizard />
+    <ProductPassportConstructor />
+  </div>
+);
 
 export default ProductPassportPage;

--- a/src/styles/app/_app-shell.css
+++ b/src/styles/app/_app-shell.css
@@ -501,6 +501,7 @@ main > .container {
 .reports-builder,
 .playbook-list,
 .passport-wizard,
+.passport-constructor,
 .alerts-stream,
 .executive-dashboard {
   position: relative;
@@ -516,7 +517,8 @@ main > .container {
 
 .reports-builder__header,
 .playbook-list__header,
-.passport-wizard__header {
+.passport-wizard__header,
+.passport-constructor__header {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -984,6 +986,558 @@ main > .container {
   display: flex;
   flex-wrap: wrap;
   gap: 0.85rem;
+}
+
+.passport-wizard__status {
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.85rem;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.92rem;
+}
+
+.passport-wizard__layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1200px) {
+  .passport-wizard__layout {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    align-items: start;
+  }
+}
+
+.passport-wizard__form {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.6rem;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.68));
+}
+
+.passport-wizard__sidebar {
+  display: grid;
+  gap: 1.35rem;
+  padding: 1.4rem;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: linear-gradient(160deg, rgba(12, 20, 32, 0.85), rgba(17, 24, 39, 0.7));
+}
+
+.passport-wizard__tabs {
+  display: inline-flex;
+  align-self: flex-start;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  padding: 0.25rem;
+  gap: 0.35rem;
+}
+
+.passport-wizard__tabs button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.passport-wizard__tabs button.active,
+.passport-wizard__tabs button:hover {
+  background: rgba(var(--netgrip-primary-accent-rgb), 0.18);
+  color: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 0 0 1px rgba(var(--netgrip-primary-accent-rgb), 0.28);
+}
+
+.passport-wizard__inventory,
+.passport-wizard__models {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.passport-wizard__search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+}
+
+.passport-wizard__search input {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0.65rem 0.95rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.passport-wizard__search input:focus {
+  outline: none;
+  border-color: rgba(94, 234, 212, 0.45);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.12);
+}
+
+.passport-wizard__search button {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(var(--netgrip-primary-accent-rgb), 0.4);
+  background: rgba(var(--netgrip-primary-accent-rgb), 0.16);
+  color: rgba(244, 244, 245, 0.9);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.passport-wizard__search button:hover {
+  background: rgba(var(--netgrip-primary-accent-rgb), 0.24);
+}
+
+.passport-wizard__results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.passport-wizard__results li {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 0.9rem;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.passport-wizard__results li[data-active='true'] {
+  border-color: rgba(var(--netgrip-primary-accent-rgb), 0.45);
+  box-shadow: 0 10px 24px rgba(15, 118, 110, 0.22);
+}
+
+.passport-wizard__results button {
+  width: 100%;
+  border: none;
+  background: rgba(15, 23, 42, 0.82);
+  color: rgba(226, 232, 240, 0.88);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.passport-wizard__results button:hover {
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.passport-wizard__results .asset {
+  font-weight: 600;
+  color: rgba(244, 244, 245, 0.92);
+}
+
+.passport-wizard__results .ip {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  text-align: right;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.passport-wizard__results .model {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.passport-wizard__results .empty {
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.62);
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.passport-wizard__device-details {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(12, 20, 32, 0.82);
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.passport-wizard__device-details dl {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.passport-wizard__device-details dl div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.passport-wizard__device-details dt {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.passport-wizard__device-details dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.passport-wizard__device-details ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.passport-wizard__device-details li {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: 0.85rem;
+}
+
+.passport-wizard__device-details .date {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.78rem;
+  color: rgba(94, 234, 212, 0.75);
+}
+
+.passport-wizard__device-details .action {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.passport-wizard__device-details .employee {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.passport-wizard__device-details .notes {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.form-field-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.passport-wizard__create,
+.passport-wizard__create-model {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(11, 18, 30, 0.9);
+  padding: 1.1rem 1.25rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.passport-wizard__create button,
+.passport-wizard__create-model button {
+  align-self: flex-start;
+}
+
+.passport-wizard__model-list {
+  display: grid;
+  gap: 0.95rem;
+}
+
+.passport-wizard__model-card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.86);
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.passport-wizard__model-card dl {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.passport-wizard__model-card dl div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.passport-wizard__model-card button {
+  justify-self: flex-start;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(var(--netgrip-primary-accent-rgb), 0.35);
+  background: rgba(var(--netgrip-primary-accent-rgb), 0.16);
+  padding: 0.55rem 0.95rem;
+  color: rgba(226, 232, 240, 0.92);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.passport-wizard__model-card button:hover {
+  background: rgba(var(--netgrip-primary-accent-rgb), 0.26);
+}
+
+.passport-wizard__create-model textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+@media (max-width: 1024px) {
+  .passport-wizard__form,
+  .passport-wizard__sidebar {
+    padding: 1.2rem;
+  }
+
+  .passport-wizard__search {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .passport-wizard__search button {
+    justify-self: flex-start;
+  }
+
+  .passport-wizard__results button {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, auto);
+  }
+
+  .passport-wizard__results .ip {
+    text-align: left;
+  }
+}
+
+.passport-constructor__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.passport-constructor__template-bar {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.passport-constructor__template-label {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.passport-constructor__template-select {
+  min-width: 220px;
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.85rem;
+  color: rgba(241, 245, 249, 0.92);
+}
+
+.passport-constructor__template-select:focus {
+  outline: none;
+  border-color: rgba(94, 234, 212, 0.65);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.15);
+}
+
+.passport-constructor__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1200px) {
+  .passport-constructor__content {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  }
+}
+
+.passport-constructor__editor {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.passport-section {
+  background: rgba(11, 16, 26, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 1.1rem;
+  padding: 1.1rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.passport-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.passport-section__title {
+  flex: 1;
+  min-width: 200px;
+}
+
+.passport-section__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.passport-row-editor {
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.85rem;
+  background: rgba(15, 23, 42, 0.78);
+}
+
+.passport-row-editor__name {
+  width: 100%;
+}
+
+.passport-row-editor__entries {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.passport-entry-editor {
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .passport-entry-editor {
+    grid-template-columns: minmax(0, 220px) minmax(0, 1fr) auto;
+  }
+}
+
+.passport-entry-editor button {
+  justify-self: end;
+}
+
+@media (max-width: 767px) {
+  .passport-entry-editor button {
+    justify-self: stretch;
+  }
+}
+
+.passport-row-editor__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.passport-constructor__preview {
+  display: grid;
+  gap: 1rem;
+  background: rgba(11, 16, 26, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 1.1rem;
+  padding: 1.1rem;
+  align-self: start;
+}
+
+.passport-preview {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.95rem;
+  padding: 1.1rem;
+  background: rgba(15, 23, 42, 0.88);
+  display: grid;
+  gap: 0.85rem;
+  max-height: 520px;
+  overflow: auto;
+}
+
+.passport-preview__section {
+  display: grid;
+  gap: 0.65rem;
+  padding-bottom: 0.8rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.passport-preview__section:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.passport-preview__row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.passport-preview__row-name {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.passport-preview__entries {
+  display: grid;
+  gap: 0.45rem;
+}
+
+@media (min-width: 640px) {
+  .passport-preview__entries {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+.passport-preview__entry {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.65rem;
+  border-radius: 0.75rem;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.passport-preview__entry-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.passport-preview__entry-value {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.95);
+  word-break: break-word;
+}
+
+.passport-preview__json {
+  font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.passport-constructor__status {
+  font-size: 0.85rem;
 }
 
 .guided-tour-card {


### PR DESCRIPTION
## Summary
- add a shared product passport context with seeded inventory/models, exported template helpers, and wrap the shell with the provider so constructor state can react to wizard selections
- rebuild the passport wizard to search inventory, show device history, create assets, manage model templates, and trigger template application in the constructor
- hook the inventory table into the shared store and refresh the wizard styling for tabs, search results, and management panels while restoring the reports builder canvas to the stable layout

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d00fcb32e8832188967b138fadfed9