### PR TITLE
Fix jsPDF import resolution

### DIFF
--- a/src/features/product-passport/ProductPassportWorkspace.tsx
+++ b/src/features/product-passport/ProductPassportWorkspace.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 
-import { jsPDF } from 'jspdf';
+import jsPDF from 'jspdf';
 
 import * as XLSX from 'xlsx';
 


### PR DESCRIPTION
## Summary
- update the jsPDF import in ProductPassportWorkspace to use the package's default export so Vite can resolve it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04416465483218704d97e6784193c