### PR TITLE
Fix jsPDF dynamic import path

### DIFF
--- a/src/features/product-passport/ProductPassportWorkspace.tsx
+++ b/src/features/product-passport/ProductPassportWorkspace.tsx
@@ -24,11 +24,15 @@ import { queryKeys } from '../../shared/api/queryKeys';
 let jsPdfModulePromise: Promise<JsPdfModule> | null = null;
 let xlsxModulePromise: Promise<XlsxModule> | null = null;
 
-const getJsPdfConstructor = async (): Promise<JsPdfConstructor> => {
+const loadJsPdfModule = () => {
   if (!jsPdfModulePromise) {
-    jsPdfModulePromise = import('jspdf');
+    jsPdfModulePromise = import('jspdf/dist/jspdf.es.min.js') as Promise<JsPdfModule>;
   }
-  const mod = await jsPdfModulePromise;
+  return jsPdfModulePromise;
+};
+
+const getJsPdfConstructor = async (): Promise<JsPdfConstructor> => {
+  const mod = await loadJsPdfModule();
   if ('jsPDF' in mod && mod.jsPDF) {
     return mod.jsPDF;
   }


### PR DESCRIPTION
## Summary
- ensure the product passport workspace lazily loads jsPDF from its ESM bundle
- reuse a shared loader helper so the jsPDF constructor resolution remains intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04a6182488321805b16171027a398