### PR TITLE
Switch product passport exports to static imports

### DIFF
--- a/src/features/product-passport/ProductPassportWorkspace.tsx
+++ b/src/features/product-passport/ProductPassportWorkspace.tsx
@@ -2,10 +2,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-
-type XlsxModule = typeof import('xlsx');
-type JsPdfModule = typeof import('jspdf');
-type JsPdfConstructor = typeof import('jspdf')['jsPDF'];
+import * as XLSX from 'xlsx';
+import { jsPDF as JsPdfConstructor } from 'jspdf';
 
 
 import Modal from '../../components/ui/Modal';
@@ -20,32 +18,6 @@ import {
   type ProductPassport,
 } from '../../entities';
 import { queryKeys } from '../../shared/api/queryKeys';
-
-let jsPdfModulePromise: Promise<JsPdfModule> | null = null;
-let xlsxModulePromise: Promise<XlsxModule> | null = null;
-
-const getJsPdfConstructor = async (): Promise<JsPdfConstructor> => {
-  if (!jsPdfModulePromise) {
-    jsPdfModulePromise = import('jspdf');
-  }
-  const mod = await jsPdfModulePromise;
-  if ('jsPDF' in mod && mod.jsPDF) {
-    return mod.jsPDF;
-  }
-  const fallback = (mod as { default?: JsPdfConstructor }).default;
-  if (fallback) {
-    return fallback;
-  }
-  throw new Error('jsPDF export is unavailable');
-};
-
-const getXlsxModule = async (): Promise<XlsxModule> => {
-  if (!xlsxModulePromise) {
-    xlsxModulePromise = import('xlsx').then(mod => (mod.default ?? mod) as XlsxModule);
-  }
-  return xlsxModulePromise;
-
-};
 
 const deviceStatusLabels: Record<DeviceStatus, string> = {
   in_service: 'В эксплуатации',
@@ -137,7 +109,6 @@ const buildExportRows = (passport: ProductPassport, history: DeviceHistoryEntry[
 };
 
 const downloadWorkbook = async (rows: Array<[string, string]>, filename: string) => {
-  const XLSX = await getXlsxModule();
   const worksheet = XLSX.utils.aoa_to_sheet(rows);
   const workbook = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Паспорт');
@@ -155,8 +126,7 @@ const downloadWorkbook = async (rows: Array<[string, string]>, filename: string)
 };
 
 const downloadPdf = async (rows: Array<[string, string]>, filename: string) => {
-  const JsPdf = await getJsPdfConstructor();
-  const doc = new JsPdf({ unit: 'pt', format: 'a4' });
+  const doc = new JsPdfConstructor({ unit: 'pt', format: 'a4' });
   const marginLeft = 48;
   const marginTop = 56;
   let cursorY = marginTop;


### PR DESCRIPTION
## Summary
- replace the lazy jsPDF loader with a direct static import so the constructor is always available
- statically import the XLSX utility helpers and drop the dynamic module resolution logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04a6182488321805b16171027a398