### PR TITLE
Refine passport export helpers

### DIFF
--- a/src/features/product-passport/ProductPassportWorkspace.tsx
+++ b/src/features/product-passport/ProductPassportWorkspace.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import * as XLSX from 'xlsx';
 import Modal from '../../components/ui/Modal';
 import {
   productPassportRepository,
@@ -117,6 +118,7 @@ const buildExportRows = (passport: ProductPassport, history: DeviceHistoryEntry[
   return rows;
 };
 
+const createExcelBlob = (rows: ExportRow[]) => {
   const worksheet = XLSX.utils.aoa_to_sheet(rows);
   const workbook = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Паспорт');
@@ -136,6 +138,23 @@ const triggerFileDownload = (blob: Blob, filename: string) => {
   setTimeout(() => URL.revokeObjectURL(link.href), 5000);
 };
 
+const downloadPassportWorkbook = (rows: ExportRow[], filename: string) => {
+  const blob = createExcelBlob(rows);
+  triggerFileDownload(blob, `${filename}.xlsx`);
+};
+
+const loadJsPdfConstructor = async () => {
+  type JsPdfCtor = typeof import('jspdf').jsPDF;
+  const module = await import('jspdf');
+  const JsPdfConstructor: JsPdfCtor | undefined = module.jsPDF ?? (module.default as JsPdfCtor | undefined);
+  if (!JsPdfConstructor) {
+    throw new Error('jsPDF constructor is unavailable');
+  }
+  return JsPdfConstructor;
+};
+
+const downloadPassportPdf = async (rows: ExportRow[], filename: string) => {
+  const JsPdfConstructor = await loadJsPdfConstructor();
   const doc = new JsPdfConstructor({ unit: 'pt', format: 'a4' });
   const marginLeft = 48;
   const marginTop = 56;
@@ -1334,11 +1353,14 @@ const PassportWizardTab: React.FC<{
       const rows = buildExportRows(passport, history);
       const filename = `${passport.metadata.assetTag}-паспорт-v${passport.version}`;
       if (type === 'excel') {
-        downloadWorkbook(rows, filename);
+        downloadPassportWorkbook(rows, filename);
       } else {
-        downloadPdf(rows, filename);
+        await downloadPassportPdf(rows, filename);
       }
       toast.success(type === 'excel' ? 'Экспортирован Excel-файл.' : 'PDF сформирован.');
+    } catch (error) {
+      console.error(error);
+      toast.error('Не удалось сформировать файл.');
     } finally {
       setExporting(false);
     }


### PR DESCRIPTION
## Summary
- rename the passport export helpers to avoid naming collisions and centralize the lazy jsPDF loader
- ensure the PDF helper reuses the shared loader while the Excel helper keeps using the blob downloader
- keep the wizard export routine pointing to the renamed helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0536db778832182923ede41543c88