### PR TITLE
Align Vegman S220 passport template with spec

### DIFF
--- a/src/app/navigation.ts
+++ b/src/app/navigation.ts
@@ -272,7 +272,7 @@ export const appNavigation: NavigationSection[] = [
         loader: loadProductPassportPage,
         group: 'Автоматизация',
         groupKey: 'navigation.sections.automation',
-        featureFlag: 'product-passport-autofill',
+        featureFlag: 'passport-wizard',
       },
     ],
   },

--- a/src/entities/product-passport/types.ts
+++ b/src/entities/product-passport/types.ts
@@ -27,23 +27,145 @@ export interface DeviceHistoryEntry {
   actor: string;
 }
 
-export type TemplateFieldType = 'text' | 'number' | 'date' | 'select' | 'checkbox' | 'multiline';
+export type TemplateFieldType =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'checkbox'
+  | 'multiline'
+  | 'table';
+
+export type TemplatePrimitiveFieldType = Exclude<TemplateFieldType, 'table'>;
+
+export interface TemplateFontStyle {
+  name?: string;
+  size?: number;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  color?: string;
+}
+
+export interface TemplateAlignmentStyle {
+  horizontal?: 'left' | 'center' | 'right';
+  vertical?: 'top' | 'middle' | 'bottom';
+  wrapText?: boolean;
+}
+
+export interface TemplateBorderStyle {
+  style?: 'thin' | 'dashed' | 'dotted' | 'medium' | 'thick';
+  color?: string;
+}
+
+export interface TemplateCellStyle {
+  font?: TemplateFontStyle;
+  alignment?: TemplateAlignmentStyle;
+  border?: {
+    top?: TemplateBorderStyle;
+    left?: TemplateBorderStyle;
+    bottom?: TemplateBorderStyle;
+    right?: TemplateBorderStyle;
+  };
+  fillColor?: string;
+  numberFormat?: string;
+}
+
+export interface TemplateMergeConfig {
+  rows?: number;
+  cols?: number;
+}
+
+export interface TemplateStaticCell {
+  id: string;
+  row: number;
+  col: number;
+  value: string;
+  merge?: TemplateMergeConfig;
+  style?: TemplateCellStyle;
+}
+
+export interface TemplateFieldBinding {
+  fieldKey: string;
+  row: number;
+  col: number;
+  prefix?: string;
+  merge?: TemplateMergeConfig;
+  style?: TemplateCellStyle;
+}
+
+export interface TemplateTableColumn {
+  id: string;
+  key: string;
+  title: string;
+  type?: TemplatePrimitiveFieldType;
+  width?: number;
+  style?: TemplateCellStyle;
+  headerStyle?: TemplateCellStyle;
+}
+
+export interface TemplateTableSection {
+  fieldKey: string;
+  row: number;
+  col: number;
+  drawHeader?: boolean;
+  showGrid?: boolean;
+  minRows?: number;
+  maxRows?: number;
+  fillEmptyRowsWithGrid?: boolean;
+  columns: TemplateTableColumn[];
+  headerStyle?: TemplateCellStyle;
+  rowStyle?: TemplateCellStyle;
+  gridStyle?: TemplateBorderStyle;
+}
+
+export interface PassportTemplateLayout {
+  sheetName: string;
+  columnWidths?: Record<number, number>;
+  rowHeights?: Record<number, number>;
+  staticCells?: TemplateStaticCell[];
+  bindings?: TemplateFieldBinding[];
+  tables?: TemplateTableSection[];
+}
 
 export interface TemplateFieldOption {
   value: string;
   label: string;
 }
 
-export interface PassportTemplateField {
+export type TemplatePrimitiveValue = string | number | boolean | string[] | null;
+export type TemplateTableRow = Record<string, TemplatePrimitiveValue>;
+export type TemplateFieldValue = TemplatePrimitiveValue | TemplateTableRow[];
+
+export interface PassportTemplatePrimitiveField {
   id: string;
   key: string;
   label: string;
-  type: TemplateFieldType;
+  type: TemplatePrimitiveFieldType;
   required?: boolean;
   placeholder?: string;
   options?: TemplateFieldOption[];
   defaultValue?: string | number | boolean | string[];
 }
+
+export interface PassportTemplateTableField {
+  id: string;
+  key: string;
+  label: string;
+  type: 'table';
+  columns: Array<{
+    id: string;
+    key: string;
+    title: string;
+    type?: TemplatePrimitiveFieldType;
+  }>;
+  minRows?: number;
+  maxRows?: number;
+  required?: boolean;
+  defaultValue?: TemplateTableRow[];
+}
+
+export type PassportTemplateField = PassportTemplatePrimitiveField | PassportTemplateTableField;
 
 export interface PassportTemplate {
   id: string;
@@ -54,6 +176,9 @@ export interface PassportTemplate {
   isActive: boolean;
   createdAt: string;
   fields: PassportTemplateField[];
+  layout?: PassportTemplateLayout;
+  status?: 'draft' | 'published' | 'archived';
+  fileNamePattern?: string;
 }
 
 export interface PassportAttachment {
@@ -90,7 +215,7 @@ export interface ProductPassport {
   updatedAt: string;
   metadata: PassportMetadata;
   schema: PassportTemplateField[];
-  fieldValues: Record<string, string | number | boolean | string[]>;
+  fieldValues: Record<string, TemplateFieldValue>;
   attachments: PassportAttachment[];
   history: ProductPassportHistoryEntry[];
 }

--- a/src/entities/state/passportsSeed.ts
+++ b/src/entities/state/passportsSeed.ts
@@ -1,4 +1,4 @@
-import type { ProductPassportState } from '../product-passport/types';
+import type { PassportTemplateLayout, ProductPassportState } from '../product-passport/types';
 import { seedReferenceTime } from './common';
 
 const now = seedReferenceTime;
@@ -81,6 +81,478 @@ const dellTemplateFields = [
   },
 ];
 
+const vegmanTemplateFields = [
+  {
+    id: 'vegman-product-name',
+    key: 'productName',
+    label: 'Наименование изделия',
+    type: 'text' as const,
+    required: true,
+  },
+  {
+    id: 'vegman-article',
+    key: 'article',
+    label: 'Артикул',
+    type: 'text' as const,
+    required: true,
+  },
+  {
+    id: 'vegman-serial',
+    key: 'serial',
+    label: 'Серийный номер',
+    type: 'text' as const,
+    required: true,
+  },
+  {
+    id: 'vegman-manufactured',
+    key: 'manufacturedAt',
+    label: 'Дата производства',
+    type: 'date' as const,
+    required: true,
+  },
+  {
+    id: 'vegman-firmware',
+    key: 'firmware',
+    label: 'Версия прошивки',
+    type: 'text' as const,
+  },
+  {
+    id: 'vegman-inspector',
+    key: 'inspector',
+    label: 'Проверяющий',
+    type: 'text' as const,
+  },
+  {
+    id: 'vegman-location',
+    key: 'location',
+    label: 'Расположение',
+    type: 'text' as const,
+  },
+  {
+    id: 'vegman-ip-address',
+    key: 'ipAddress',
+    label: 'IP-адрес',
+    type: 'text' as const,
+  },
+  {
+    id: 'vegman-responsible',
+    key: 'responsible',
+    label: 'Ответственный',
+    type: 'text' as const,
+  },
+  {
+    id: 'vegman-notes',
+    key: 'notes',
+    label: 'Примечания',
+    type: 'multiline' as const,
+  },
+  {
+    id: 'vegman-components',
+    key: 'components',
+    label: 'Комплектующие',
+    type: 'table' as const,
+    minRows: 0,
+    maxRows: 50,
+    columns: [
+      { id: 'vegman-components-name', key: 'name', title: 'Наименование', type: 'text' as const },
+      { id: 'vegman-components-pn', key: 'pn', title: 'Part Number', type: 'text' as const },
+      { id: 'vegman-components-qty', key: 'qty', title: 'Кол-во', type: 'number' as const },
+      { id: 'vegman-components-remark', key: 'remark', title: 'Примечание', type: 'text' as const },
+    ],
+  },
+];
+
+const vegmanTemplateLayout: PassportTemplateLayout = {
+  sheetName: 'Документ',
+  columnWidths: { 2: 20, 3: 45, 4: 30, 5: 15 },
+  rowHeights: { 2: 28, 13: 20, 14: 20, 15: 20, 18: 20 },
+  staticCells: [
+    {
+      id: 'vegman-title',
+      row: 2,
+      col: 2,
+      value: 'ПАСПОРТ ИЗДЕЛИЯ',
+      merge: { cols: 4 },
+      style: {
+        font: { name: 'Calibri', size: 16, bold: true },
+        alignment: { horizontal: 'center', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-subtitle',
+      row: 4,
+      col: 2,
+      value: 'Модель:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-model-value',
+      row: 4,
+      col: 3,
+      value: 'S220',
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-organization-label',
+      row: 5,
+      col: 2,
+      value: 'Организация:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-organization-value',
+      row: 5,
+      col: 3,
+      value: '<наименование организации>',
+      merge: { cols: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-product-label',
+      row: 6,
+      col: 2,
+      value: 'Наименование:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-article-label',
+      row: 7,
+      col: 2,
+      value: 'Артикул:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-serial-label',
+      row: 8,
+      col: 2,
+      value: 'Серийный №:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-date-label',
+      row: 9,
+      col: 2,
+      value: 'Дата произв.:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-firmware-label',
+      row: 10,
+      col: 2,
+      value: 'Прошивка:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-inspector-label',
+      row: 11,
+      col: 2,
+      value: 'Проверил:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-location-label',
+      row: 12,
+      col: 2,
+      value: 'Расположение:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-notes-label',
+      row: 13,
+      col: 2,
+      value: 'Примечания:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-ip-label',
+      row: 16,
+      col: 2,
+      value: 'IP-адрес:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-responsible-label',
+      row: 17,
+      col: 2,
+      value: 'Ответственный:',
+      style: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'right', vertical: 'middle' },
+      },
+    },
+    {
+      id: 'vegman-qr-frame',
+      row: 8,
+      col: 5,
+      value: '',
+      merge: { rows: 4 },
+      style: {
+        border: {
+          top: { style: 'thin' },
+          bottom: { style: 'thin' },
+          left: { style: 'thin' },
+          right: { style: 'thin' },
+        },
+      },
+    },
+  ],
+  bindings: [
+    {
+      fieldKey: 'productName',
+      row: 6,
+      col: 3,
+      merge: { cols: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle', wrapText: true },
+      },
+    },
+    {
+      fieldKey: 'article',
+      row: 7,
+      col: 3,
+      merge: { cols: 2 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'serial',
+      row: 8,
+      col: 3,
+      merge: { cols: 2 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'manufacturedAt',
+      row: 9,
+      col: 3,
+      merge: { cols: 2 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+        numberFormat: 'dd.mm.yyyy',
+      },
+    },
+    {
+      fieldKey: 'firmware',
+      row: 10,
+      col: 3,
+      merge: { cols: 2 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'inspector',
+      row: 11,
+      col: 3,
+      merge: { cols: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'location',
+      row: 12,
+      col: 3,
+      merge: { cols: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'notes',
+      row: 13,
+      col: 3,
+      merge: { cols: 3, rows: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'top', wrapText: true },
+        border: {
+          top: { style: 'thin' },
+          bottom: { style: 'thin' },
+          left: { style: 'thin' },
+          right: { style: 'thin' },
+        },
+      },
+    },
+    {
+      fieldKey: 'ipAddress',
+      row: 16,
+      col: 3,
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+    {
+      fieldKey: 'responsible',
+      row: 17,
+      col: 3,
+      merge: { cols: 3 },
+      style: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'middle' },
+      },
+    },
+  ],
+  tables: [
+    {
+      fieldKey: 'components',
+      row: 18,
+      col: 2,
+      drawHeader: true,
+      showGrid: true,
+      minRows: 0,
+      maxRows: 50,
+      fillEmptyRowsWithGrid: true,
+      columns: [
+        {
+          id: 'vegman-components-name-col',
+          key: 'name',
+          title: 'Наименование',
+          type: 'text' as const,
+          width: 30,
+          style: {
+            font: { name: 'Calibri', size: 11 },
+            alignment: { horizontal: 'left', vertical: 'top', wrapText: true },
+          },
+          headerStyle: {
+            font: { name: 'Calibri', size: 11, bold: true },
+            alignment: { horizontal: 'center', vertical: 'middle' },
+            border: {
+              top: { style: 'thin' },
+              bottom: { style: 'thin' },
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+            },
+          },
+        },
+        {
+          id: 'vegman-components-pn-col',
+          key: 'pn',
+          title: 'Part Number',
+          type: 'text' as const,
+          width: 20,
+          style: {
+            font: { name: 'Calibri', size: 11 },
+            alignment: { horizontal: 'left', vertical: 'top', wrapText: true },
+          },
+          headerStyle: {
+            font: { name: 'Calibri', size: 11, bold: true },
+            alignment: { horizontal: 'center', vertical: 'middle' },
+            border: {
+              top: { style: 'thin' },
+              bottom: { style: 'thin' },
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+            },
+          },
+        },
+        {
+          id: 'vegman-components-qty-col',
+          key: 'qty',
+          title: 'Кол-во',
+          type: 'number' as const,
+          width: 8,
+          style: {
+            font: { name: 'Calibri', size: 11 },
+            alignment: { horizontal: 'center', vertical: 'middle' },
+            numberFormat: '0',
+          },
+          headerStyle: {
+            font: { name: 'Calibri', size: 11, bold: true },
+            alignment: { horizontal: 'center', vertical: 'middle' },
+            border: {
+              top: { style: 'thin' },
+              bottom: { style: 'thin' },
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+            },
+          },
+        },
+        {
+          id: 'vegman-components-note-col',
+          key: 'remark',
+          title: 'Примечание',
+          type: 'text' as const,
+          width: 30,
+          style: {
+            font: { name: 'Calibri', size: 11 },
+            alignment: { horizontal: 'left', vertical: 'top', wrapText: true },
+          },
+          headerStyle: {
+            font: { name: 'Calibri', size: 11, bold: true },
+            alignment: { horizontal: 'center', vertical: 'middle' },
+            border: {
+              top: { style: 'thin' },
+              bottom: { style: 'thin' },
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+            },
+          },
+        },
+      ],
+      headerStyle: {
+        font: { name: 'Calibri', size: 11, bold: true },
+        alignment: { horizontal: 'center', vertical: 'middle' },
+      },
+      rowStyle: {
+        font: { name: 'Calibri', size: 11 },
+        alignment: { horizontal: 'left', vertical: 'top', wrapText: true },
+      },
+      gridStyle: { style: 'thin', color: '#000000' },
+    },
+  ],
+} as const;
+
 export const passportsSeed: ProductPassportState = {
   devices: [
     {
@@ -113,6 +585,16 @@ export const passportsSeed: ProductPassportState = {
       owner: 'Команда безопасности',
       status: 'in_service',
     },
+    {
+      id: 'device-vegman-220-01',
+      assetTag: 'VG-220-01',
+      deviceModelId: 'model-vegman-s220',
+      serialNumber: 'S220-VEGMAN-0001',
+      ipAddress: '10.55.0.20',
+      location: 'Цех 2 / Линия Vegman',
+      owner: 'Команда производственной автоматики',
+      status: 'in_service',
+    },
   ],
   deviceModels: [
     {
@@ -133,6 +615,12 @@ export const passportsSeed: ProductPassportState = {
       name: 'Juniper SRX340',
       description: 'Пограничный межсетевой экран и VPN-шлюз.',
     },
+    {
+      id: 'model-vegman-s220',
+      vendor: 'Vegman',
+      name: 'S220',
+      description: 'Компактный терминал Vegman S220 для индустриальных IoT-сценариев.',
+    },
   ],
   templates: [
     {
@@ -144,6 +632,7 @@ export const passportsSeed: ProductPassportState = {
       isActive: true,
       createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 30).toISOString(),
       fields: ciscoTemplateFields.map(field => ({ ...field })),
+      status: 'published',
     },
     {
       id: 'tpl-dell-base-v1',
@@ -154,6 +643,20 @@ export const passportsSeed: ProductPassportState = {
       isActive: true,
       createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 45).toISOString(),
       fields: dellTemplateFields.map(field => ({ ...field })),
+      status: 'published',
+    },
+    {
+      id: 'tpl-vegman-s220-v1',
+      deviceModelId: 'model-vegman-s220',
+      name: 'Vegman S220 — паспорт изделия',
+      description: 'Эталонный паспорт Vegman S220 с таблицей комплектующих.',
+      version: 1,
+      isActive: true,
+      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+      fields: vegmanTemplateFields.map(field => ({ ...field })),
+      layout: vegmanTemplateLayout,
+      status: 'published',
+      fileNamePattern: 'Паспорт_S220_{serial}',
     },
   ],
   passports: [

--- a/src/features/product-passport/export/__tests__/templateWorkbook.test.ts
+++ b/src/features/product-passport/export/__tests__/templateWorkbook.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PassportTemplate, ProductPassport } from '../../../../entities';
+import { createWorkbookFromTemplate } from '../templateWorkbook';
+
+const buildTemplate = (): PassportTemplate => ({
+  id: 'tpl-test',
+  deviceModelId: 'model-test',
+  name: 'Тестовый шаблон',
+  version: 1,
+  isActive: true,
+  createdAt: new Date().toISOString(),
+  fields: [
+    {
+      id: 'field-date',
+      key: 'manufacturedAt',
+      label: 'Дата производства',
+      type: 'date',
+      required: true,
+    },
+    {
+      id: 'field-components',
+      key: 'components',
+      label: 'Комплектующие',
+      type: 'table',
+      minRows: 1,
+      maxRows: 3,
+      columns: [
+        {
+          id: 'col-name',
+          key: 'name',
+          title: 'Наименование',
+          type: 'text',
+        },
+        {
+          id: 'col-qty',
+          key: 'qty',
+          title: 'Кол-во',
+          type: 'number',
+        },
+      ],
+    },
+  ],
+  layout: {
+    sheetName: 'Документ',
+    columnWidths: { 2: 30, 3: 12 },
+    rowHeights: { 5: 20 },
+    staticCells: [
+      {
+        id: 'label-date',
+        row: 4,
+        col: 2,
+        value: 'Дата произв.:',
+        style: { font: { bold: true }, alignment: { horizontal: 'right', vertical: 'middle' } },
+      },
+    ],
+    bindings: [
+      {
+        fieldKey: 'manufacturedAt',
+        row: 4,
+        col: 3,
+        merge: { cols: 2 },
+        style: { alignment: { horizontal: 'left', vertical: 'middle' }, numberFormat: 'dd.mm.yyyy' },
+      },
+    ],
+    tables: [
+      {
+        fieldKey: 'components',
+        row: 6,
+        col: 2,
+        drawHeader: true,
+        showGrid: true,
+        minRows: 1,
+        maxRows: 3,
+        fillEmptyRowsWithGrid: true,
+        columns: [
+          {
+            id: 'col-name',
+            key: 'name',
+            title: 'Наименование',
+            type: 'text',
+            width: 30,
+            style: { alignment: { horizontal: 'left', vertical: 'top', wrapText: true } },
+            headerStyle: {
+              font: { bold: true },
+              alignment: { horizontal: 'center', vertical: 'middle' },
+              border: {
+                top: { style: 'thin' },
+                bottom: { style: 'thin' },
+                left: { style: 'thin' },
+                right: { style: 'thin' },
+              },
+            },
+          },
+          {
+            id: 'col-qty',
+            key: 'qty',
+            title: 'Кол-во',
+            type: 'number',
+            width: 10,
+            style: { alignment: { horizontal: 'center', vertical: 'middle' }, numberFormat: '0' },
+            headerStyle: {
+              font: { bold: true },
+              alignment: { horizontal: 'center', vertical: 'middle' },
+              border: {
+                top: { style: 'thin' },
+                bottom: { style: 'thin' },
+                left: { style: 'thin' },
+                right: { style: 'thin' },
+              },
+            },
+          },
+        ],
+        headerStyle: { font: { bold: true }, alignment: { horizontal: 'center', vertical: 'middle' } },
+        rowStyle: { alignment: { horizontal: 'left', vertical: 'top', wrapText: true } },
+        gridStyle: { style: 'thin', color: '#000000' },
+      },
+    ],
+  },
+});
+
+const buildPassport = (): ProductPassport => ({
+  id: 'passport-test',
+  deviceId: 'device-test',
+  templateId: 'tpl-test',
+  status: 'draft',
+  version: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  metadata: {
+    assetTag: 'VG-01',
+    modelName: 'Vegman Test',
+    vendor: 'Vegman',
+    serialNumber: 'SER-1',
+    ipAddress: '10.0.0.1',
+    location: 'Линия 1',
+    owner: 'Команда QA',
+  },
+  schema: [],
+  fieldValues: {
+    manufacturedAt: '2024-05-01',
+    components: [
+      { name: 'Контроллер', qty: 1 },
+      { name: 'Адаптер питания', qty: 2 },
+    ],
+  },
+  attachments: [],
+  history: [],
+});
+
+describe('createWorkbookFromTemplate', () => {
+  it('renders styled cells, date formats and grid-aligned tables', async () => {
+    const template = buildTemplate();
+    const passport = buildPassport();
+
+    const workbook = await createWorkbookFromTemplate(template, passport);
+    const worksheet = workbook.getWorksheet('Документ');
+
+    expect(worksheet).toBeDefined();
+    const dateCell = worksheet!.getCell('C4') as MockCell;
+    expect(dateCell.value).toBeInstanceOf(Date);
+    expect(dateCell.numFmt).toBe('dd.mm.yyyy');
+
+    const headerCell = worksheet!.getCell('B6') as MockCell;
+    expect(headerCell.value).toBe('Наименование');
+    expect((headerCell.border?.top as { style?: string })?.style).toBe('thin');
+
+    const firstRowName = worksheet!.getCell('B7') as MockCell;
+    const firstRowQty = worksheet!.getCell('C7') as MockCell;
+    expect(firstRowName.value).toBe('Контроллер');
+    expect(firstRowQty.value).toBe(1);
+    expect(firstRowQty.numFmt).toBe('0');
+
+    const emptyRow = worksheet!.getCell('B9') as MockCell;
+    expect(emptyRow.value).toBe('');
+    expect((emptyRow.border?.left as { style?: string })?.style).toBe('thin');
+  });
+});
+
+class MockCell {
+  value: unknown = '';
+  font?: Record<string, unknown>;
+  alignment?: Record<string, unknown>;
+  border?: Record<string, unknown>;
+  fill?: Record<string, unknown>;
+  numFmt?: string;
+}
+
+class MockWorksheet {
+  name: string;
+  private cells = new Map<string, MockCell>();
+  private columns = new Map<number, { width?: number }>();
+  private rows = new Map<number, { height?: number }>();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  private resolveAddress(row: number | string, col?: number) {
+    if (typeof row === 'string') {
+      return row;
+    }
+    const columnLetter = String.fromCharCode(64 + (col ?? 1));
+    return `${columnLetter}${row}`;
+  }
+
+  getCell(row: number | string, col?: number) {
+    const address = this.resolveAddress(row, col);
+    if (!this.cells.has(address)) {
+      this.cells.set(address, new MockCell());
+    }
+    return this.cells.get(address)!;
+  }
+
+  getColumn(index: number) {
+    if (!this.columns.has(index)) {
+      this.columns.set(index, {});
+    }
+    return this.columns.get(index)!;
+  }
+
+  getRow(index: number) {
+    if (!this.rows.has(index)) {
+      this.rows.set(index, {});
+    }
+    return this.rows.get(index)!;
+  }
+
+  mergeCells() {
+    // no-op for tests
+  }
+}
+
+class MockWorkbook {
+  worksheets: MockWorksheet[] = [];
+  xlsx = {
+    async writeBuffer() {
+      return new ArrayBuffer(0);
+    },
+  };
+
+  addWorksheet(name: string, _options?: unknown) {
+    const worksheet = new MockWorksheet(name);
+    this.worksheets.push(worksheet);
+    return worksheet;
+  }
+
+  getWorksheet(name: string) {
+    return this.worksheets.find(sheet => sheet.name === name);
+  }
+}
+
+vi.mock('exceljs', () => ({
+  Workbook: MockWorkbook,
+  default: { Workbook: MockWorkbook },
+}));

--- a/src/features/product-passport/export/__tests__/templateWorkbook.test.ts
+++ b/src/features/product-passport/export/__tests__/templateWorkbook.test.ts
@@ -239,7 +239,7 @@ class MockWorkbook {
     },
   };
 
-  addWorksheet(name: string, _options?: unknown) {
+  addWorksheet(name: string) {
     const worksheet = new MockWorksheet(name);
     this.worksheets.push(worksheet);
     return worksheet;

--- a/src/features/product-passport/export/passportExportDownload.ts
+++ b/src/features/product-passport/export/passportExportDownload.ts
@@ -1,24 +1,51 @@
-import type { Worksheet } from 'exceljs';
+import type { PassportTemplate } from '../../../entities';
+import type { ProductPassport } from '../../../entities/product-passport/types';
 import type { ExportRow } from './passportExportRows';
+import { createWorkbookFromTemplate } from './templateWorkbook';
 
-type ExceljsModule = typeof import('exceljs');
 type JsPdfCtor = typeof import('jspdf').jsPDF;
 
-let exceljsModulePromise: Promise<ExceljsModule> | null = null;
 let jsPdfCtorPromise: Promise<JsPdfCtor> | null = null;
 
-const loadExceljsModule = async (): Promise<ExceljsModule> => {
-  if (!exceljsModulePromise) {
-    exceljsModulePromise = import('exceljs').then(module => {
-      const resolved = (module as { default?: ExceljsModule }).default;
-      const exceljs = (resolved ?? module) as ExceljsModule;
-      if (!exceljs.Workbook) {
-        throw new Error('exceljs module is missing Workbook constructor');
-      }
-      return exceljs;
-    });
+const INVALID_FILENAME_CHARS = /[\\/:*?"<>|]+/g;
+
+const normalizeFilenameSegment = (value: string) =>
+  value
+    .trim()
+    .replace(INVALID_FILENAME_CHARS, '')
+    .replace(/\s+/g, '_');
+
+const ensureSafeFilename = (value: string, fallback = 'passport') => {
+  const normalized = normalizeFilenameSegment(value);
+  return normalized || fallback;
+};
+
+const extractSerialValue = (passport: ProductPassport) => {
+  const candidates = ['serial', 'serialNumber'];
+  for (const key of candidates) {
+    const raw = passport.fieldValues[key];
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim();
+    }
+    if (typeof raw === 'number') {
+      return String(raw);
+    }
   }
-  return exceljsModulePromise;
+  return passport.metadata.serialNumber?.trim() ?? '';
+};
+
+export const buildPassportFilename = (
+  template: PassportTemplate | null,
+  passport: ProductPassport,
+) => {
+  if (template?.fileNamePattern) {
+    const serialRaw = extractSerialValue(passport);
+    const safeSerial = ensureSafeFilename(serialRaw, 'без_серийника');
+    const patternResult = template.fileNamePattern.replace('{serial}', safeSerial);
+    return ensureSafeFilename(patternResult, `passport_${passport.version}`);
+  }
+  const base = `${passport.metadata.assetTag || 'passport'}-паспорт-v${passport.version}`;
+  return ensureSafeFilename(base);
 };
 
 const loadJsPdfConstructor = async (): Promise<JsPdfCtor> => {
@@ -35,86 +62,6 @@ const loadJsPdfConstructor = async (): Promise<JsPdfCtor> => {
   return jsPdfCtorPromise;
 };
 
-const resolveTemplateUrl = () => {
-  const templateUrl = import.meta.env.VITE_VEGMAN_PASSPORT_TEMPLATE_URL;
-  if (!templateUrl) {
-    throw new Error(
-      'Vegman passport template URL is not configured. Set VITE_VEGMAN_PASSPORT_TEMPLATE_URL to a reachable .xlsx template.',
-    );
-  }
-  return templateUrl;
-};
-const DATA_START_ROW = 6;
-const TEMPLATE_LAST_ROW = 150;
-const LABEL_COLUMN = 'B';
-const VALUE_COLUMN = 'D';
-
-const fetchTemplateWorkbook = async (ExcelJS: ExceljsModule) => {
-  const templateUrl = resolveTemplateUrl();
-  const response = await fetch(templateUrl);
-  if (!response.ok) {
-    throw new Error(`Template is unavailable (${response.status})`);
-  }
-  const templateBuffer = await response.arrayBuffer();
-  const workbook = new ExcelJS.Workbook();
-  await workbook.xlsx.load(templateBuffer);
-  return workbook;
-};
-
-const updateTimestamp = (worksheet: Worksheet) => {
-  const labelCell = worksheet.getCell('E4');
-  if (!labelCell.value) {
-    labelCell.value = 'Дата выгрузки:';
-  }
-  labelCell.font = { name: 'Calibri', size: 10, italic: true, color: { argb: 'FF4F81BD' } };
-  labelCell.alignment = { vertical: 'middle', horizontal: 'right' };
-
-  const dateCell = worksheet.getCell('F4');
-  dateCell.value = new Date();
-  dateCell.font = { name: 'Calibri', size: 10, italic: true, color: { argb: 'FF4F81BD' } };
-  dateCell.alignment = { vertical: 'middle', horizontal: 'left' };
-  dateCell.numFmt = 'dd.mm.yyyy hh:mm';
-};
-
-const clearRemainingRows = (worksheet: Worksheet, fromRow: number) => {
-  for (let rowIndex = fromRow; rowIndex <= TEMPLATE_LAST_ROW; rowIndex += 1) {
-    const labelCell = worksheet.getCell(`${LABEL_COLUMN}${rowIndex}`);
-    const valueCell = worksheet.getCell(`${VALUE_COLUMN}${rowIndex}`);
-    if (labelCell.value || valueCell.value) {
-      labelCell.value = '';
-      valueCell.value = '';
-    }
-  }
-};
-
-const fillWorksheetWithRows = (worksheet: Worksheet, rows: ExportRow[]) => {
-  rows.forEach(([label, value], index) => {
-    const rowNumber = DATA_START_ROW + index;
-    const labelCell = worksheet.getCell(`${LABEL_COLUMN}${rowNumber}`);
-    const valueCell = worksheet.getCell(`${VALUE_COLUMN}${rowNumber}`);
-    labelCell.value = label ?? '';
-    valueCell.value = value ?? '';
-  });
-
-  const nextRow = DATA_START_ROW + rows.length;
-  clearRemainingRows(worksheet, nextRow);
-};
-
-const createExcelBlob = async (rows: ExportRow[]): Promise<Blob> => {
-  const ExcelJS = await loadExceljsModule();
-  const workbook = await fetchTemplateWorkbook(ExcelJS);
-  const worksheet = workbook.getWorksheet('Паспорт') ?? workbook.worksheets[0];
-  if (!worksheet) {
-    throw new Error('Template sheet is missing');
-  }
-  updateTimestamp(worksheet);
-  fillWorksheetWithRows(worksheet, rows);
-  const arrayBuffer = await workbook.xlsx.writeBuffer();
-  return new Blob([arrayBuffer], {
-    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  });
-};
-
 const triggerFileDownload = (blob: Blob, filename: string) => {
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
@@ -125,9 +72,18 @@ const triggerFileDownload = (blob: Blob, filename: string) => {
   setTimeout(() => URL.revokeObjectURL(link.href), 5000);
 };
 
-export const downloadPassportWorkbook = async (rows: ExportRow[], filename: string) => {
-  const blob = await createExcelBlob(rows);
-  triggerFileDownload(blob, `${filename}.xlsx`);
+export const downloadPassportWorkbook = async (
+  template: PassportTemplate,
+  passport: ProductPassport,
+  filename: string,
+) => {
+  const workbook = await createWorkbookFromTemplate(template, passport);
+  const arrayBuffer = await workbook.xlsx.writeBuffer();
+  const blob = new Blob([arrayBuffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+  const safeName = ensureSafeFilename(filename);
+  triggerFileDownload(blob, `${safeName}.xlsx`);
 };
 
 export const downloadPassportPdf = async (rows: ExportRow[], filename: string) => {
@@ -137,8 +93,10 @@ export const downloadPassportPdf = async (rows: ExportRow[], filename: string) =
   const marginTop = 56;
   let cursorY = marginTop;
 
+  const safeName = ensureSafeFilename(filename);
+
   doc.setFontSize(16);
-  doc.text(`Паспорт изделия ${filename}`, marginLeft, cursorY);
+  doc.text(`Паспорт изделия ${safeName}`, marginLeft, cursorY);
   cursorY += 24;
 
   const writeRow = (left: string, right: string) => {
@@ -165,5 +123,5 @@ export const downloadPassportPdf = async (rows: ExportRow[], filename: string) =
     writeRow(left, right);
   });
 
-  doc.save(`${filename}.pdf`);
+  doc.save(`${safeName}.pdf`);
 };

--- a/src/features/product-passport/export/passportExportRows.ts
+++ b/src/features/product-passport/export/passportExportRows.ts
@@ -2,14 +2,23 @@ import type {
   DeviceHistoryEntry,
   ProductPassport,
 } from '../../../entities';
-import type { TemplateFieldValue } from '../types';
+import type { TemplateFieldValue, TemplateTableRow } from '../types';
 import { formatPassportDateTime } from '../utils/date';
 
 export type ExportRow = [string, string];
 
 const formatFieldValue = (value: TemplateFieldValue | undefined) => {
   if (Array.isArray(value)) {
-    return value.join(', ');
+    if (value.length > 0 && typeof value[0] === 'object' && value[0] !== null) {
+      const rows = value as TemplateTableRow[];
+      return rows
+        .map((row, index) => {
+          const entries = Object.values(row ?? {}).filter(cell => cell !== undefined && cell !== '');
+          return `${index + 1}. ${entries.length > 0 ? entries.join(', ') : '—'}`;
+        })
+        .join('\n');
+    }
+    return (value as Array<string | number | boolean | string[]>).join(', ');
   }
   if (typeof value === 'boolean') {
     return value ? 'Да' : 'Нет';

--- a/src/features/product-passport/export/templateWorkbook.ts
+++ b/src/features/product-passport/export/templateWorkbook.ts
@@ -1,0 +1,341 @@
+import type {
+  PassportTemplate,
+  PassportTemplateField,
+  PassportTemplateLayout,
+  TemplateCellStyle,
+  TemplateFieldBinding,
+  TemplateFieldValue,
+  TemplateStaticCell,
+  TemplateTableSection,
+  TemplateTableRow,
+} from '../../../entities';
+import type { ProductPassport } from '../../../entities/product-passport/types';
+
+type ExcelCell = {
+  value: unknown;
+  font?: Record<string, unknown>;
+  alignment?: Record<string, unknown>;
+  border?: Record<string, unknown>;
+  fill?: Record<string, unknown>;
+  numFmt?: string;
+};
+
+type ExcelWorksheet = {
+  getCell(row: number | string, col?: number): ExcelCell;
+  mergeCells(startRow: number, startCol: number, endRow: number, endCol: number): void;
+  getColumn(index: number): { width?: number };
+  getRow(index: number): { height?: number };
+};
+
+type ExcelWorkbook = {
+  worksheets: ExcelWorksheet[];
+  addWorksheet(
+    name: string,
+    options?: { properties?: Record<string, unknown>; pageSetup?: Record<string, unknown> },
+  ): ExcelWorksheet;
+  getWorksheet(name: string): ExcelWorksheet | undefined;
+  readonly xlsx: {
+    writeBuffer(): Promise<ArrayBuffer>;
+  };
+};
+
+type ExceljsModule = {
+  Workbook: new () => ExcelWorkbook;
+};
+
+const isTableField = (field: PassportTemplateField): field is Extract<PassportTemplateField, { type: 'table' }> =>
+  field.type === 'table';
+
+const toExcelColor = (color?: string) => {
+  if (!color) {
+    return undefined;
+  }
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    return hex.length === 6 ? `FF${hex.toUpperCase()}` : hex.toUpperCase();
+  }
+  if (color.length === 6) {
+    return `FF${color.toUpperCase()}`;
+  }
+  if (color.length === 8) {
+    return color.toUpperCase();
+  }
+  return undefined;
+};
+
+const applyCellStyle = (cell: ExcelCell, style?: TemplateCellStyle) => {
+  if (!style) {
+    return;
+  }
+  if (style.font) {
+    cell.font = {
+      name: style.font.name,
+      size: style.font.size,
+      bold: style.font.bold,
+      italic: style.font.italic,
+      underline: style.font.underline,
+      color: style.font.color ? { argb: toExcelColor(style.font.color) } : undefined,
+    };
+  }
+  if (style.alignment) {
+    cell.alignment = {
+      horizontal: style.alignment.horizontal,
+      vertical: style.alignment.vertical,
+      wrapText: style.alignment.wrapText,
+    };
+  }
+  if (style.border) {
+    const convertBorder = (border?: { style?: string; color?: string }) =>
+      border
+        ? {
+            style: border.style,
+            color: border.color ? { argb: toExcelColor(border.color) } : undefined,
+          }
+        : undefined;
+    cell.border = {
+      top: convertBorder(style.border.top),
+      bottom: convertBorder(style.border.bottom),
+      left: convertBorder(style.border.left),
+      right: convertBorder(style.border.right),
+    };
+  }
+  if (style.fillColor) {
+    const color = toExcelColor(style.fillColor);
+    if (color) {
+      cell.fill = {
+        type: 'pattern',
+        pattern: 'solid',
+        fgColor: { argb: color },
+      };
+    }
+  }
+  if (style.numberFormat) {
+    cell.numFmt = style.numberFormat;
+  }
+};
+
+const mergeIfNeeded = (worksheet: ExcelWorksheet, cell: TemplateStaticCell | TemplateFieldBinding) => {
+  if (!cell.merge) {
+    return;
+  }
+  const rows = Math.max(1, cell.merge.rows ?? 1);
+  const cols = Math.max(1, cell.merge.cols ?? 1);
+  if (rows > 1 || cols > 1) {
+    worksheet.mergeCells(cell.row, cell.col, cell.row + rows - 1, cell.col + cols - 1);
+  }
+};
+
+const formatValue = (field: PassportTemplateField, value: TemplateFieldValue | undefined): string | number | Date | boolean => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (isTableField(field)) {
+    return '';
+  }
+  if (field.type === 'date') {
+    if (typeof value === 'string') {
+      const parsed = Date.parse(value);
+      return Number.isNaN(parsed) ? value : new Date(parsed);
+    }
+    if (value instanceof Date) {
+      return value;
+    }
+  }
+  if (field.type === 'number') {
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const num = Number(value);
+      return Number.isNaN(num) ? value : num;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return value as string | number | boolean;
+};
+
+const applyStaticCells = (worksheet: ExcelWorksheet, cells: TemplateStaticCell[] = []) => {
+  cells.forEach(cell => {
+    const excelCell = worksheet.getCell(cell.row, cell.col);
+    excelCell.value = cell.value;
+    applyCellStyle(excelCell, cell.style);
+    mergeIfNeeded(worksheet, cell);
+  });
+};
+
+const applyFieldBindings = (
+  worksheet: ExcelWorksheet,
+  fields: PassportTemplateField[],
+  bindings: TemplateFieldBinding[] = [],
+  values: Record<string, TemplateFieldValue>,
+) => {
+  bindings.forEach(binding => {
+    const field = fields.find(item => item.key === binding.fieldKey);
+    if (!field) {
+      return;
+    }
+    const value = values[field.key];
+    const excelCell = worksheet.getCell(binding.row, binding.col);
+    const formatted = formatValue(field, value);
+    excelCell.value = binding.prefix ? `${binding.prefix}${formatted ?? ''}` : formatted;
+    applyCellStyle(excelCell, binding.style);
+    mergeIfNeeded(worksheet, binding);
+  });
+};
+
+const applyTableSection = (
+  worksheet: ExcelWorksheet,
+  section: TemplateTableSection,
+  field: Extract<PassportTemplateField, { type: 'table' }>,
+  rowsValue: TemplateFieldValue | undefined,
+) => {
+  if (!Array.isArray(rowsValue)) {
+    return;
+  }
+  const rows = rowsValue as TemplateTableRow[];
+  const minRows = section.minRows ?? field.minRows ?? 0;
+  const maxRows = section.maxRows ?? field.maxRows ?? undefined;
+  const headerRowIndex = section.row;
+  const startRow = section.drawHeader ? headerRowIndex + 1 : headerRowIndex;
+  const shouldFillEmpty = (section.fillEmptyRowsWithGrid ?? true) && section.showGrid;
+  const gridBorder =
+    section.showGrid && section.gridStyle
+      ? {
+          style: section.gridStyle.style,
+          color: section.gridStyle.color ? { argb: toExcelColor(section.gridStyle.color) } : undefined,
+        }
+      : null;
+
+  if (section.drawHeader) {
+    section.columns.forEach((column, index) => {
+      if (column.width) {
+        worksheet.getColumn(section.col + index).width = column.width;
+      }
+      const cell = worksheet.getCell(headerRowIndex, section.col + index);
+      cell.value = column.title;
+      applyCellStyle(cell, column.headerStyle ?? section.headerStyle);
+      if (gridBorder) {
+        cell.border = {
+          top: gridBorder,
+          bottom: gridBorder,
+          left: gridBorder,
+          right: gridBorder,
+        };
+      }
+    });
+  }
+
+  const effectiveRows = Math.max(rows.length, minRows);
+  const limitedRows = maxRows ? Math.min(effectiveRows, maxRows) : effectiveRows;
+  const totalRows = shouldFillEmpty && maxRows ? maxRows : limitedRows;
+
+  for (let rowIndex = 0; rowIndex < totalRows; rowIndex += 1) {
+    const rowValue = rows[rowIndex] ?? {};
+    section.columns.forEach((column, columnIndex) => {
+      if (column.width) {
+        worksheet.getColumn(section.col + columnIndex).width = column.width;
+      }
+      const cell = worksheet.getCell(startRow + rowIndex, section.col + columnIndex);
+      const raw = rowValue[column.key];
+      if (Array.isArray(raw)) {
+        cell.value = raw.join(', ');
+      } else {
+        cell.value = raw ?? '';
+      }
+      applyCellStyle(cell, column.style ?? section.rowStyle);
+      if (gridBorder) {
+        cell.border = {
+          top: gridBorder,
+          bottom: gridBorder,
+          left: gridBorder,
+          right: gridBorder,
+        };
+      }
+    });
+  }
+};
+
+const applyTables = (
+  worksheet: ExcelWorksheet,
+  fields: PassportTemplateField[],
+  tables: TemplateTableSection[] = [],
+  values: Record<string, TemplateFieldValue>,
+) => {
+  tables.forEach(section => {
+    const field = fields.find(item => item.key === section.fieldKey);
+    if (!field || !isTableField(field)) {
+      return;
+    }
+    applyTableSection(worksheet, section, field, values[field.key]);
+  });
+};
+
+const configureDimensions = (worksheet: ExcelWorksheet, layout: PassportTemplateLayout) => {
+  if (layout.columnWidths) {
+    Object.entries(layout.columnWidths).forEach(([index, width]) => {
+      const numericIndex = Number(index);
+      if (!Number.isNaN(numericIndex)) {
+        worksheet.getColumn(numericIndex).width = width;
+      }
+    });
+  }
+  if (layout.rowHeights) {
+    Object.entries(layout.rowHeights).forEach(([index, height]) => {
+      const numericIndex = Number(index);
+      if (!Number.isNaN(numericIndex)) {
+        worksheet.getRow(numericIndex).height = height;
+      }
+    });
+  }
+};
+
+export const populateWorksheetFromLayout = (
+  worksheet: ExcelWorksheet,
+  template: PassportTemplate,
+  passport: ProductPassport,
+) => {
+  const layout = template.layout;
+  if (!layout) {
+    throw new Error('Template layout is not defined');
+  }
+  configureDimensions(worksheet, layout);
+  applyStaticCells(worksheet, layout.staticCells);
+  applyFieldBindings(worksheet, template.fields, layout.bindings, passport.fieldValues);
+  applyTables(worksheet, template.fields, layout.tables, passport.fieldValues);
+};
+
+let excelModulePromise: Promise<ExceljsModule> | null = null;
+
+const loadExcelModule = async () => {
+  if (!excelModulePromise) {
+    excelModulePromise = import('exceljs').then(mod => {
+      const candidate = ((mod as unknown) as { default?: ExceljsModule }).default ?? (mod as unknown as ExceljsModule);
+      if (!candidate || !candidate.Workbook) {
+        throw new Error('exceljs module missing Workbook export');
+      }
+      return candidate;
+    });
+  }
+  return excelModulePromise;
+};
+
+export const createWorkbookFromTemplate = async (
+  template: PassportTemplate,
+  passport: ProductPassport,
+): Promise<ExcelWorkbook> => {
+  if (!template.layout) {
+    throw new Error('Template layout is required to build workbook');
+  }
+  const ExcelJS = await loadExcelModule();
+  const workbook = new ExcelJS.Workbook();
+  const sheetName = template.layout.sheetName || 'Паспорт';
+  const worksheet = workbook.addWorksheet(sheetName, {
+    properties: { defaultRowHeight: 20 },
+    pageSetup: { paperSize: 9, orientation: 'portrait' },
+  });
+  populateWorksheetFromLayout(worksheet, template, passport);
+  return workbook;
+};
+

--- a/src/features/product-passport/types.ts
+++ b/src/features/product-passport/types.ts
@@ -1,1 +1,1 @@
-export type TemplateFieldValue = string | number | boolean | string[];
+export type { TemplateFieldValue, TemplateTableRow, TemplatePrimitiveValue } from '../../entities/product-passport/types';

--- a/src/features/product-passport/workspace/components/TemplateEditorModal.tsx
+++ b/src/features/product-passport/workspace/components/TemplateEditorModal.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { toast } from 'sonner';
 
 import Modal from '../../../../components/ui/Modal';
-import type { DeviceModel } from '../../../../entities';
+import type { DeviceModel, TemplatePrimitiveFieldType } from '../../../../entities';
 import type { TemplateCreationPayload, TemplateFieldDraft } from '../types';
-import { createBlankFieldDraft, normalizeFieldDraft } from '../utils';
+import { createBlankFieldDraft, generateTempId, normalizeFieldDraft } from '../utils';
 
 export interface TemplateEditorModalProps {
   isOpen: boolean;
@@ -27,6 +27,7 @@ export const TemplateEditorModal = ({
   const [deviceModelId, setDeviceModelId] = useState(defaultModelId ?? models[0]?.id ?? '');
   const [setActive, setSetActive] = useState(true);
   const [fields, setFields] = useState<TemplateFieldDraft[]>([createBlankFieldDraft()]);
+  const [layoutDraft, setLayoutDraft] = useState('');
   const [isSubmitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -56,6 +57,16 @@ export const TemplateEditorModal = ({
       toast.error('Добавьте хотя бы одно поле.');
       return;
     }
+    let parsedLayout: TemplateCreationPayload['layout'] = undefined;
+    if (layoutDraft.trim()) {
+      try {
+        parsedLayout = JSON.parse(layoutDraft);
+      } catch (error) {
+        console.error(error);
+        toast.error('Не удалось разобрать JSON разметки Excel.');
+        return;
+      }
+    }
     setSubmitting(true);
     try {
       await onSubmit({
@@ -65,10 +76,13 @@ export const TemplateEditorModal = ({
         setActive,
         isActive: setActive,
         fields: normalizedFields,
+        layout: parsedLayout,
+        status: setActive ? 'published' : 'draft',
       });
       setName('');
       setDescription('');
       setFields([createBlankFieldDraft()]);
+      setLayoutDraft('');
       toast.success('Шаблон сохранён.');
       onClose();
     } catch {
@@ -167,7 +181,27 @@ export const TemplateEditorModal = ({
                     onChange={event => {
                       const nextType = event.target.value as TemplateFieldDraft['type'];
                       setFields(current =>
-                        current.map(item => (item.id === field.id ? { ...item, type: nextType } : item)),
+                        current.map(item =>
+                          item.id === field.id
+                            ? {
+                                ...item,
+                                type: nextType,
+                                columns:
+                                  nextType === 'table'
+                                    ? item.columns.length > 0
+                                      ? item.columns
+                                      : [
+                                          {
+                                            id: generateTempId(),
+                                            title: 'Колонка',
+                                            key: 'column',
+                                            type: 'text',
+                                          },
+                                        ]
+                                    : item.columns,
+                              }
+                            : item,
+                        ),
                       );
                     }}
                   >
@@ -177,6 +211,7 @@ export const TemplateEditorModal = ({
                     <option value="select">Список</option>
                     <option value="checkbox">Флажок</option>
                     <option value="multiline">Многострочный текст</option>
+                    <option value="table">Таблица</option>
                   </select>
                 </label>
                 {field.type === 'select' ? (
@@ -194,21 +229,186 @@ export const TemplateEditorModal = ({
                       />
                   </label>
                 ) : null}
-                <label>
-                  Значение по умолчанию
-                  <input
-                    value={field.defaultValue ?? ''}
-                    onChange={event =>
-                      setFields(current =>
-                        current.map(item =>
-                          item.id === field.id ? { ...item, defaultValue: event.target.value } : item,
-                        ),
-                      )
-                    }
-                    placeholder="Например, Готов"
-                  />
-                </label>
+                {field.type !== 'table' ? (
+                  <label>
+                    Значение по умолчанию
+                    <input
+                      value={field.defaultValue ?? ''}
+                      onChange={event =>
+                        setFields(current =>
+                          current.map(item =>
+                            item.id === field.id ? { ...item, defaultValue: event.target.value } : item,
+                          ),
+                        )
+                      }
+                      placeholder="Например, Готов"
+                    />
+                  </label>
+                ) : null}
               </div>
+              {field.type === 'table' ? (
+                <div className="passport-row-editor__table">
+                  <div className="passport-row-editor__table-controls">
+                    <label>
+                      Мин. строк
+                      <input
+                        type="number"
+                        min={0}
+                        value={field.minRows ?? ''}
+                        onChange={event =>
+                          setFields(current =>
+                            current.map(item =>
+                              item.id === field.id
+                                ? {
+                                    ...item,
+                                    minRows: event.target.value ? Number(event.target.value) : undefined,
+                                  }
+                                : item,
+                            ),
+                          )
+                        }
+                      />
+                    </label>
+                    <label>
+                      Макс. строк
+                      <input
+                        type="number"
+                        min={0}
+                        value={field.maxRows ?? ''}
+                        onChange={event =>
+                          setFields(current =>
+                            current.map(item =>
+                              item.id === field.id
+                                ? {
+                                    ...item,
+                                    maxRows: event.target.value ? Number(event.target.value) : undefined,
+                                  }
+                                : item,
+                            ),
+                          )
+                        }
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="secondary"
+                      onClick={() =>
+                        setFields(current =>
+                          current.map(item =>
+                            item.id === field.id
+                              ? {
+                                  ...item,
+                                  columns: [
+                                    ...item.columns,
+                                    {
+                                      id: generateTempId(),
+                                      title: 'Новый столбец',
+                                      key: '',
+                                      type: 'text',
+                                    },
+                                  ],
+                                }
+                              : item,
+                          ),
+                        )
+                      }
+                    >
+                      Добавить столбец
+                    </button>
+                  </div>
+                  <div className="passport-row-editor__table-columns">
+                    {field.columns.map(column => (
+                      <div key={column.id} className="passport-row-editor__table-column">
+                        <label>
+                          Название столбца
+                          <input
+                            value={column.title}
+                            onChange={event =>
+                              setFields(current =>
+                                current.map(item =>
+                                  item.id === field.id
+                                    ? {
+                                        ...item,
+                                        columns: item.columns.map(col =>
+                                          col.id === column.id ? { ...col, title: event.target.value } : col,
+                                        ),
+                                      }
+                                    : item,
+                                ),
+                              )
+                            }
+                          />
+                        </label>
+                        <label>
+                          Ключ
+                          <input
+                            value={column.key}
+                            onChange={event =>
+                              setFields(current =>
+                                current.map(item =>
+                                  item.id === field.id
+                                    ? {
+                                        ...item,
+                                        columns: item.columns.map(col =>
+                                          col.id === column.id ? { ...col, key: event.target.value } : col,
+                                        ),
+                                      }
+                                    : item,
+                                ),
+                              )
+                            }
+                          />
+                        </label>
+                        <label>
+                          Тип
+                          <select
+                            value={column.type}
+                            onChange={event =>
+                              setFields(current =>
+                                current.map(item =>
+                                  item.id === field.id
+                                    ? {
+                                        ...item,
+                                        columns: item.columns.map(col =>
+                                          col.id === column.id
+                                            ? { ...col, type: event.target.value as TemplatePrimitiveFieldType }
+                                            : col,
+                                        ),
+                                      }
+                                    : item,
+                                ),
+                              )
+                            }
+                          >
+                            <option value="text">Текст</option>
+                            <option value="number">Число</option>
+                            <option value="date">Дата</option>
+                          </select>
+                        </label>
+                        <button
+                          type="button"
+                          className="ghost"
+                          onClick={() =>
+                            setFields(current =>
+                              current.map(item =>
+                                item.id === field.id
+                                  ? {
+                                      ...item,
+                                      columns: item.columns.filter(col => col.id !== column.id),
+                                    }
+                                  : item,
+                              ),
+                            )
+                          }
+                          disabled={field.columns.length === 1}
+                        >
+                          Удалить столбец
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
               <div className="passport-row-editor__controls">
                 <label className="checkbox-field">
                   <input
@@ -235,6 +435,21 @@ export const TemplateEditorModal = ({
               </div>
             </div>
           ))}
+        </div>
+        <div className="passport-section">
+          <div className="passport-section__header">
+            <h3 className="passport-section__title">Разметка Excel (JSON)</h3>
+          </div>
+          <textarea
+            value={layoutDraft}
+            onChange={event => setLayoutDraft(event.target.value)}
+            rows={8}
+            placeholder={'{ "sheetName": "Документ" }'}
+          />
+          <p className="muted">
+            Укажите JSON-схему листа: ширины колонок, статические ячейки, привязки полей и секции таблиц.
+            При сохранении выполняется базовая проверка синтаксиса.
+          </p>
         </div>
         <div className="modal-footer">
           <button type="button" className="secondary" onClick={onClose}>

--- a/src/features/product-passport/workspace/tabs/TemplatesTab.tsx
+++ b/src/features/product-passport/workspace/tabs/TemplatesTab.tsx
@@ -28,6 +28,8 @@ export const TemplatesTab = ({ templates, models }: TemplatesTabProps) => {
         fields: payload.fields,
         isActive: payload.setActive,
         setActive: payload.setActive,
+        layout: payload.layout,
+        status: payload.status,
       }),
     onSuccess: template => {
       queryClient.invalidateQueries({ queryKey: queryKeys.productPassports.templates() });
@@ -90,7 +92,13 @@ export const TemplatesTab = ({ templates, models }: TemplatesTabProps) => {
                     <td>v{template.version}</td>
                     <td>{template.fields.length}</td>
                     <td>{new Date(template.createdAt).toLocaleDateString('ru-RU')}</td>
-                    <td>{template.isActive ? 'Активен' : 'Черновик'}</td>
+                    <td>
+                      {template.status === 'archived'
+                        ? 'Архив'
+                        : template.status === 'published' || template.isActive
+                        ? 'Опубликован'
+                        : 'Черновик'}
+                    </td>
                     <td>
                       <button
                         type="button"

--- a/src/features/product-passport/workspace/types.ts
+++ b/src/features/product-passport/workspace/types.ts
@@ -1,7 +1,9 @@
 import type {
   DeviceModel,
   DeviceStatus,
+  PassportTemplate,
   PassportTemplateField,
+  TemplatePrimitiveFieldType,
 } from '../../../entities';
 
 export type DeviceFormValues = {
@@ -24,6 +26,14 @@ export type TemplateFieldDraft = {
   options: string;
   placeholder?: string;
   defaultValue?: string;
+  columns: Array<{
+    id: string;
+    title: string;
+    key: string;
+    type: TemplatePrimitiveFieldType;
+  }>;
+  minRows?: number;
+  maxRows?: number;
 };
 
 export type TemplateCreationPayload = {
@@ -33,6 +43,8 @@ export type TemplateCreationPayload = {
   setActive: boolean;
   isActive: boolean;
   fields: PassportTemplateField[];
+  layout?: PassportTemplate['layout'];
+  status?: PassportTemplate['status'];
 };
 
 export type ModelLookup = Map<string, DeviceModel>;

--- a/src/features/product-passport/workspace/utils.ts
+++ b/src/features/product-passport/workspace/utils.ts
@@ -1,9 +1,4 @@
-import type {
-  DeviceModel,
-  PassportTemplateField,
-  ProductPassport,
-  TemplatePrimitiveFieldType,
-} from '../../../entities';
+import type { DeviceModel, PassportTemplateField, ProductPassport } from '../../../entities';
 import type { TemplateFieldValue } from '../types';
 import type { DeviceFormValues, TemplateFieldDraft } from './types';
 
@@ -42,14 +37,14 @@ export const normalizeFieldDraft = (draft: TemplateFieldDraft): PassportTemplate
       type: 'table',
       minRows: draft.minRows,
       maxRows: draft.maxRows,
-          columns: draft.columns
-            .filter(column => column.title.trim())
-            .map(column => ({
-              id: column.id,
-              title: column.title,
-              key: column.key || createSlug(column.title) || column.id,
-              type: column.type ?? 'text',
-            })),
+      columns: draft.columns
+        .filter(column => column.title.trim())
+        .map(column => ({
+          id: column.id,
+          title: column.title,
+          key: column.key || createSlug(column.title) || column.id,
+          type: column.type ?? 'text',
+        })),
     };
   }
   return {

--- a/src/features/product-passport/workspace/utils.ts
+++ b/src/features/product-passport/workspace/utils.ts
@@ -1,4 +1,9 @@
-import type { DeviceModel, PassportTemplateField, ProductPassport } from '../../../entities';
+import type {
+  DeviceModel,
+  PassportTemplateField,
+  ProductPassport,
+  TemplatePrimitiveFieldType,
+} from '../../../entities';
 import type { TemplateFieldValue } from '../types';
 import type { DeviceFormValues, TemplateFieldDraft } from './types';
 
@@ -17,25 +22,54 @@ export const createBlankFieldDraft = (): TemplateFieldDraft => ({
   type: 'text',
   required: true,
   options: '',
+  columns: [
+    {
+      id: generateTempId(),
+      title: 'Столбец',
+      key: 'columnKey',
+      type: 'text',
+    },
+  ],
 });
 
-export const normalizeFieldDraft = (draft: TemplateFieldDraft): PassportTemplateField => ({
-  id: draft.id,
-  key: draft.key || createSlug(draft.label) || draft.id,
-  label: draft.label,
-  type: draft.type,
-  required: draft.required,
-  placeholder: draft.placeholder,
-  defaultValue: draft.type === 'number' ? Number(draft.defaultValue) : draft.defaultValue,
-  options:
-    draft.type === 'select'
-      ? draft.options
-          .split(',')
-          .map(item => item.trim())
-          .filter(Boolean)
-          .map(item => ({ label: item, value: createSlug(item) }))
-      : undefined,
-});
+export const normalizeFieldDraft = (draft: TemplateFieldDraft): PassportTemplateField => {
+  const key = draft.key || createSlug(draft.label) || draft.id;
+  if (draft.type === 'table') {
+    return {
+      id: draft.id,
+      key,
+      label: draft.label,
+      type: 'table',
+      minRows: draft.minRows,
+      maxRows: draft.maxRows,
+          columns: draft.columns
+            .filter(column => column.title.trim())
+            .map(column => ({
+              id: column.id,
+              title: column.title,
+              key: column.key || createSlug(column.title) || column.id,
+              type: column.type ?? 'text',
+            })),
+    };
+  }
+  return {
+    id: draft.id,
+    key,
+    label: draft.label,
+    type: draft.type,
+    required: draft.required,
+    placeholder: draft.placeholder,
+    defaultValue: draft.type === 'number' ? Number(draft.defaultValue) : draft.defaultValue,
+    options:
+      draft.type === 'select'
+        ? draft.options
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean)
+            .map(item => ({ label: item, value: createSlug(item) }))
+        : undefined,
+  };
+};
 
 export const createDefaultDeviceFormValues = (models: DeviceModel[]): DeviceFormValues => ({
   assetTag: '',
@@ -59,6 +93,9 @@ export const getMissingRequired = (
       if (field.type === 'checkbox') {
         return value !== true;
       }
+      if (field.type === 'table') {
+        return !Array.isArray(value) || value.length === 0;
+      }
       if (Array.isArray(value)) {
         return value.length === 0;
       }
@@ -78,7 +115,15 @@ export const buildDetailDefaults = (passport: ProductPassport): Record<string, T
       defaults[field.key] = field.defaultValue;
       return;
     }
-    defaults[field.key] = field.type === 'checkbox' ? false : '';
+    if (field.type === 'checkbox') {
+      defaults[field.key] = false;
+      return;
+    }
+    if (field.type === 'table') {
+      defaults[field.key] = [];
+      return;
+    }
+    defaults[field.key] = '';
   });
   return defaults;
 };

--- a/src/shared/config/featureFlags.ts
+++ b/src/shared/config/featureFlags.ts
@@ -4,6 +4,8 @@ export type FeatureFlag =
   | 'reports-builder'
   | 'executive-dashboard-insights'
   | 'automation-playbooks'
+  | 'passport-wizard'
+  | 'template-builder'
   | 'product-passport-autofill'
   | 'navigation-diagnostics-export'
   | 'mes-command-center'
@@ -19,6 +21,8 @@ const activeFlags: Record<FeatureFlag, boolean> = {
   'reports-builder': true,
   'executive-dashboard-insights': true,
   'automation-playbooks': true,
+  'passport-wizard': true,
+  'template-builder': true,
   'product-passport-autofill': true,
   'navigation-diagnostics-export': true,
   'mes-command-center': true,

--- a/src/styles/app/_app-shell.css
+++ b/src/styles/app/_app-shell.css
@@ -1232,6 +1232,58 @@ main > .container {
   gap: 0.6rem;
 }
 
+.passport-row-editor__table {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+}
+
+.passport-row-editor__table-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.passport-row-editor__table-controls label {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 120px;
+}
+
+.passport-row-editor__table-columns {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.passport-row-editor__table-column {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 0.65rem;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.passport-table-editor {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.passport-table-editor__actions {
+  width: 120px;
+  text-align: center;
+}
+
+.passport-table-editor__controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .passport-constructor__preview {
   display: grid;
   gap: 1rem;

--- a/src/types/exceljs.d.ts
+++ b/src/types/exceljs.d.ts
@@ -1,0 +1,32 @@
+declare module 'exceljs' {
+  export class Cell {
+    value: unknown;
+    font?: Record<string, unknown>;
+    alignment?: Record<string, unknown>;
+    border?: Record<string, unknown>;
+    fill?: Record<string, unknown>;
+  }
+
+  export class Worksheet {
+    name: string;
+    getCell(row: number | string, col?: number): Cell;
+    getColumn(index: number): { width?: number };
+    getRow(index: number): { height?: number };
+    mergeCells(startRow: number, startCol: number, endRow: number, endCol: number): void;
+  }
+
+  export class Workbook {
+    worksheets: Worksheet[];
+    addWorksheet(name: string, options?: { properties?: Record<string, unknown>; pageSetup?: Record<string, unknown> }): Worksheet;
+    getWorksheet(name: string): Worksheet | undefined;
+    readonly xlsx: {
+      writeBuffer(): Promise<ArrayBuffer>;
+    };
+  }
+
+  const exceljs: {
+    Workbook: typeof Workbook;
+  };
+
+  export default exceljs;
+}


### PR DESCRIPTION
## Summary
- realign the Vegman S220 seed template fields, Excel layout, and filename mask with the supplied passport map
- extend workbook rendering to honor number formats, draw grid lines through empty rows, and sanitize export filenames from template patterns
- propagate the new style metadata through repository clones/autofill and update the workbook test to assert formatted cells and grid padding

## Testing
- npm run typecheck
- npm run test -- templateWorkbook

------
https://chatgpt.com/codex/tasks/task_e_68d105bd6c688321adf4f824c9ebc004