### PR TITLE
Refine MES layouts and align console cards

### DIFF
--- a/src/features/mes/FirmwareFlashingConsole.tsx
+++ b/src/features/mes/FirmwareFlashingConsole.tsx
@@ -276,14 +276,14 @@ export const FirmwareFlashingConsole: React.FC = () => {
   };
 
   return (
-    <section className="firmware-console" aria-label="Консоль прошивки">
-      <header className="firmware-console__header">
-        <div>
+    <section className="mes-layout firmware-console" aria-label="Консоль прошивки">
+      <header className="mes-layout__hero">
+        <div className="mes-layout__hero-main">
           <h1>Прошивка устройств</h1>
           <p className="muted">
             Управляйте стендами прошивки, контролируйте версии и прослеживаемость для серверов и дронов в одной панели.
           </p>
-          <div className="firmware-console__metrics">
+          <div className="mes-layout__stats firmware-console__metrics">
             <div className="metric">
               <span className="metric__label">Всего прошивок сегодня</span>
               <span className="metric__value">{totalJobs}</span>
@@ -306,7 +306,7 @@ export const FirmwareFlashingConsole: React.FC = () => {
             </div>
           </div>
         </div>
-        <aside className="firmware-console__agents">
+        <aside className="mes-card firmware-console__agents">
           <h2>Состояние агентов</h2>
           <ul>
             {agents.map(agent => (
@@ -332,8 +332,8 @@ export const FirmwareFlashingConsole: React.FC = () => {
         </aside>
       </header>
 
-      <div className="firmware-console__content">
-        <section className="firmware-console__panels" aria-label="Панели прошивки">
+      <div className="mes-layout__columns firmware-console__workspace">
+        <section className="mes-layout__primary firmware-console__panels" aria-label="Панели прошивки">
           <div className="firmware-console__panel-actions">
             <button type="button" className="primary" disabled={readyPorts.length === 0}>
               Прошить всё подключённое ({readyPorts.length})
@@ -653,7 +653,7 @@ export const FirmwareFlashingConsole: React.FC = () => {
           </div>
         </section>
 
-        <aside className="firmware-console__sidebar">
+        <aside className="mes-layout__secondary firmware-console__sidebar">
           <section className="firmware-console__presets" aria-label="Шаблоны прошивки">
             <header>
               <h2>Шаблоны конфигураций</h2>
@@ -694,7 +694,7 @@ export const FirmwareFlashingConsole: React.FC = () => {
         </aside>
       </div>
 
-      <section className="firmware-console__summary" aria-label="Сводка прошивок">
+      <section className="mes-card firmware-console__summary mes-layout__full" aria-label="Сводка прошивок">
         <header>
           <div>
             <h2>Сводка прошивок</h2>

--- a/src/features/mes/ManufacturingCommandCenter.tsx
+++ b/src/features/mes/ManufacturingCommandCenter.tsx
@@ -80,193 +80,195 @@ export const ManufacturingCommandCenter: React.FC = () => {
   }, [workOrders]);
 
   return (
-    <section className="mes-command" aria-label="Командный центр MES">
-      <header className="mes-command__header">
-        <div>
+    <section className="mes-layout mes-command" aria-label="Командный центр MES">
+      <header className="mes-layout__hero">
+        <div className="mes-layout__hero-main">
           <h1>Командный центр MES</h1>
           <p className="muted">
             Стратегическое управление производством: разделите value stream&rsquo;ы, синхронизируйте смены и держите под
             контролем критические блокеры.
           </p>
         </div>
-        <div className="mes-command__actions">
+        <div className="mes-layout__hero-actions mes-command__actions">
           <button type="button" className="primary">Синхронизировать с ERP</button>
           <button type="button" className="secondary">Экспортировать план смен</button>
         </div>
       </header>
-      <div className="mes-command__grid">
-        <article className="mes-command__card">
-          <header className="mes-command__card-header">
-            <div>
-              <h2>Портфель заказов</h2>
-              <p className="muted">Ключевые статусы и динамика по текущей неделе.</p>
-            </div>
-            <span className="badge">{orderSummary.total}</span>
-          </header>
-          <div className="mes-command__metrics">
-            {orderSummary.statuses.map(item => (
-              <div key={item.status} className="metric">
-                <span className="metric__label">{item.label}</span>
-                <span className="metric__value">{formatNumber(item.count)}</span>
+      <div className="mes-layout__primary">
+        <div className="mes-command__grid">
+          <article className="mes-card mes-command__card">
+            <header className="mes-command__card-header">
+              <div>
+                <h2>Портфель заказов</h2>
+                <p className="muted">Ключевые статусы и динамика по текущей неделе.</p>
               </div>
-            ))}
-          </div>
-          <footer className="mes-command__footer">
-            <span className="chip chip--ghost">
-              <span className="chip__label">Срок &lt; 72ч</span>
-              <span className="chip__value">{orderSummary.dueSoon}</span>
-            </span>
-            <span className="chip chip--ghost">
-              <span className="chip__label">Активных операций</span>
-              <span className="chip__value">
-                {workOrders.filter(item => item.status === 'in-progress').length}
+              <span className="badge">{orderSummary.total}</span>
+            </header>
+            <div className="mes-command__metrics">
+              {orderSummary.statuses.map(item => (
+                <div key={item.status} className="metric">
+                  <span className="metric__label">{item.label}</span>
+                  <span className="metric__value">{formatNumber(item.count)}</span>
+                </div>
+              ))}
+            </div>
+            <footer className="mes-command__footer">
+              <span className="chip chip--ghost">
+                <span className="chip__label">Срок &lt; 72ч</span>
+                <span className="chip__value">{orderSummary.dueSoon}</span>
               </span>
-            </span>
-          </footer>
-        </article>
-        <article className="mes-command__card mes-command__card--stretch">
-          <header className="mes-command__card-header">
-            <div>
-              <h2>Производственные линии</h2>
-              <p className="muted">Нагрузка, такт и доступность по потокам.</p>
-            </div>
-          </header>
-          <ul className="mes-command__list">
-            {loadByLine.map(line => (
-              <li key={line.id}>
-                <div className="mes-command__line-body">
-                  <div className="mes-command__line-heading">
-                    <strong>{line.name}</strong>
-                    <span className="chip chip--muted">Смена {line.shiftPattern}</span>
-                  </div>
-                  <p className="muted">
-                    Такт {Math.round(line.taktTimeSec / 60)} мин · План {line.targetPerShift} шт/смена · Факт {line.throughputPerShift} шт
-                  </p>
-                  {line.blockers.length > 0 && (
-                    <p className="alert">Блокеры: {line.blockers.join(', ')}</p>
-                  )}
-                  <div className="mes-command__line-indicators">
-                    <span className="chip">
-                      <span className="chip__label">WIP</span>
-                      <span className="chip__value">{line.currentWip}</span>
-                    </span>
-                    <span className="chip">
-                      <span className="chip__label">Очередь</span>
-                      <span className="chip__value">{line.wipOrders}</span>
-                    </span>
-                    <span className="chip">
-                      <span className="chip__label">Работает</span>
-                      <span className="chip__value">{line.active}</span>
-                    </span>
-                    <span className="chip">
-                      <span className="chip__label">OEE</span>
-                      <span className="chip__value">{formatPercent(line.availability)}</span>
-                    </span>
-                  </div>
-                </div>
-              </li>
-            ))}
-            {loadByLine.length === 0 && <li className="muted">Нет активных линий</li>}
-          </ul>
-        </article>
-        <article className="mes-command__card">
-          <header className="mes-command__card-header">
-            <div>
-              <h2>Value stream сегментация</h2>
-              <p className="muted">Разделённые зоны ответственности и точки эскалации.</p>
-            </div>
-          </header>
-          <ul className="mes-command__streams">
-            {valueStreams.map(stream => (
-              <li key={stream.id}>
-                <div className="mes-command__stream-body">
-                  <div className="mes-command__stream-heading">
-                    <strong>{stream.name}</strong>
-                    <span className="chip chip--accent">{stream.focus}</span>
-                  </div>
-                  <div className="mes-command__stream-metrics">
-                    <span className="chip">
-                      <span className="chip__label">Спрос недели</span>
-                      <span className="chip__value">{stream.demandThisWeek}</span>
-                    </span>
-                    <span className="chip">
-                      <span className="chip__label">Незакрытый бэклог</span>
-                      <span className="chip__value">{stream.backlogUnits}</span>
-                    </span>
-                    <span className={`chip chip--risk-${stream.riskLevel}`}>
-                      <span className="chip__label">Риск</span>
-                      <span className="chip__value">{stream.riskLevel}</span>
-                    </span>
-                  </div>
-                  <div className="mes-command__stream-meta">
-                    <span className="chip chip--ghost">
-                      <span className="chip__label">Группы доступа</span>
-                      <span className="chip__value">{stream.gatekeepers.join(', ')}</span>
-                    </span>
-                    <span className="chip chip--ghost">
-                      <span className="chip__label">Следующий рубеж</span>
-                      <span className="chip__value">{stream.nextMilestone}</span>
-                    </span>
-                  </div>
-                </div>
-              </li>
-            ))}
-            {valueStreams.length === 0 && <li className="muted">Value stream&apos;ы не назначены</li>}
-          </ul>
-        </article>
-        <article className="mes-command__card">
-          <header className="mes-command__card-header">
-            <div>
-              <h2>Нагрузка рабочих центров</h2>
-              <p className="muted">Контроль WIP и доступности по всем зонам.</p>
-            </div>
-          </header>
-          <table className="mes-command__table">
-            <thead>
-              <tr>
-                <th>Рабочий центр</th>
-                <th>В очереди</th>
-                <th>В работе</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Array.from(workCentersLoad.entries()).map(([wcId, stats]) => {
-                const center = workCenterMap.get(wcId);
-                return (
-                  <tr key={wcId}>
-                    <td>
-                      <div className="mes-command__wc-name">
-                        <strong>{center?.name ?? wcId}</strong>
-                        {center?.capabilityTags.length ? (
-                          <span className="chip chip--muted">{center.capabilityTags.join(', ')}</span>
-                        ) : null}
-                      </div>
-                    </td>
-                    <td>
+              <span className="chip chip--ghost">
+                <span className="chip__label">Активных операций</span>
+                <span className="chip__value">
+                  {workOrders.filter(item => item.status === 'in-progress').length}
+                </span>
+              </span>
+            </footer>
+          </article>
+          <article className="mes-card mes-command__card mes-command__card--stretch">
+            <header className="mes-command__card-header">
+              <div>
+                <h2>Производственные линии</h2>
+                <p className="muted">Нагрузка, такт и доступность по потокам.</p>
+              </div>
+            </header>
+            <ul className="mes-command__list">
+              {loadByLine.map(line => (
+                <li key={line.id}>
+                  <div className="mes-command__line-body">
+                    <div className="mes-command__line-heading">
+                      <strong>{line.name}</strong>
+                      <span className="chip chip--muted">Смена {line.shiftPattern}</span>
+                    </div>
+                    <p className="muted">
+                      Такт {Math.round(line.taktTimeSec / 60)} мин · План {line.targetPerShift} шт/смена · Факт {line.throughputPerShift} шт
+                    </p>
+                    {line.blockers.length > 0 && (
+                      <p className="alert">Блокеры: {line.blockers.join(', ')}</p>
+                    )}
+                    <div className="mes-command__line-indicators">
+                      <span className="chip">
+                        <span className="chip__label">WIP</span>
+                        <span className="chip__value">{line.currentWip}</span>
+                      </span>
                       <span className="chip">
                         <span className="chip__label">Очередь</span>
-                        <span className="chip__value">{stats.backlog}</span>
+                        <span className="chip__value">{line.wipOrders}</span>
                       </span>
-                    </td>
-                    <td>
                       <span className="chip">
-                        <span className="chip__label">В работе</span>
-                        <span className="chip__value">{stats.running}</span>
+                        <span className="chip__label">Работает</span>
+                        <span className="chip__value">{line.active}</span>
                       </span>
+                      <span className="chip">
+                        <span className="chip__label">OEE</span>
+                        <span className="chip__value">{formatPercent(line.availability)}</span>
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              ))}
+              {loadByLine.length === 0 && <li className="muted">Нет активных линий</li>}
+            </ul>
+          </article>
+          <article className="mes-card mes-command__card">
+            <header className="mes-command__card-header">
+              <div>
+                <h2>Value stream сегментация</h2>
+                <p className="muted">Разделённые зоны ответственности и точки эскалации.</p>
+              </div>
+            </header>
+            <ul className="mes-command__streams">
+              {valueStreams.map(stream => (
+                <li key={stream.id}>
+                  <div className="mes-command__stream-body">
+                    <div className="mes-command__stream-heading">
+                      <strong>{stream.name}</strong>
+                      <span className="chip chip--accent">{stream.focus}</span>
+                    </div>
+                    <div className="mes-command__stream-metrics">
+                      <span className="chip">
+                        <span className="chip__label">Спрос недели</span>
+                        <span className="chip__value">{stream.demandThisWeek}</span>
+                      </span>
+                      <span className="chip">
+                        <span className="chip__label">Незакрытый бэклог</span>
+                        <span className="chip__value">{stream.backlogUnits}</span>
+                      </span>
+                      <span className={`chip chip--risk-${stream.riskLevel}`}>
+                        <span className="chip__label">Риск</span>
+                        <span className="chip__value">{stream.riskLevel}</span>
+                      </span>
+                    </div>
+                    <div className="mes-command__stream-meta">
+                      <span className="chip chip--ghost">
+                        <span className="chip__label">Группы доступа</span>
+                        <span className="chip__value">{stream.gatekeepers.join(', ')}</span>
+                      </span>
+                      <span className="chip chip--ghost">
+                        <span className="chip__label">Следующий рубеж</span>
+                        <span className="chip__value">{stream.nextMilestone}</span>
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              ))}
+              {valueStreams.length === 0 && <li className="muted">Value stream&apos;ы не назначены</li>}
+            </ul>
+          </article>
+          <article className="mes-card mes-command__card">
+            <header className="mes-command__card-header">
+              <div>
+                <h2>Нагрузка рабочих центров</h2>
+                <p className="muted">Контроль WIP и доступности по всем зонам.</p>
+              </div>
+            </header>
+            <table className="mes-command__table">
+              <thead>
+                <tr>
+                  <th>Рабочий центр</th>
+                  <th>В очереди</th>
+                  <th>В работе</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from(workCentersLoad.entries()).map(([wcId, stats]) => {
+                  const center = workCenterMap.get(wcId);
+                  return (
+                    <tr key={wcId}>
+                      <td>
+                        <div className="mes-command__wc-name">
+                          <strong>{center?.name ?? wcId}</strong>
+                          {center?.capabilityTags.length ? (
+                            <span className="chip chip--muted">{center.capabilityTags.join(', ')}</span>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td>
+                        <span className="chip">
+                          <span className="chip__label">Очередь</span>
+                          <span className="chip__value">{stats.backlog}</span>
+                        </span>
+                      </td>
+                      <td>
+                        <span className="chip">
+                          <span className="chip__label">В работе</span>
+                          <span className="chip__value">{stats.running}</span>
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {workCentersLoad.size === 0 && (
+                  <tr>
+                    <td colSpan={3} className="muted">
+                      Нет активных рабочих центров
                     </td>
                   </tr>
-                );
-              })}
-              {workCentersLoad.size === 0 && (
-                <tr>
-                  <td colSpan={3} className="muted">
-                    Нет активных рабочих центров
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </article>
+                )}
+              </tbody>
+            </table>
+          </article>
+        </div>
       </div>
     </section>
   );

--- a/src/features/mes/ProductionDashboard.tsx
+++ b/src/features/mes/ProductionDashboard.tsx
@@ -496,13 +496,13 @@ export const ProductionDashboard: React.FC = () => {
 
 
   return (
-    <section className="mes-production" aria-label="Операции производства">
-      <header className="mes-production__header">
-        <div>
+    <section className="mes-layout mes-production" aria-label="Операции производства">
+      <header className="mes-layout__hero">
+        <div className="mes-layout__hero-main">
           <h1>Операционное управление производством</h1>
           <p className="muted">Контролируйте портфель заказов, загрузку смены и качество на одном экране.</p>
         </div>
-        <div className="mes-production__actions">
+        <div className="mes-layout__hero-actions mes-production__actions">
           <button type="button" className="secondary">
             Сводка смены
           </button>
@@ -512,7 +512,8 @@ export const ProductionDashboard: React.FC = () => {
         </div>
       </header>
 
-      <div className="mes-production__summary" role="list">
+      <div className="mes-layout__primary">
+        <div className="mes-production__summary" role="list">
         <div className="mes-production__summary-card" role="listitem">
           <span className="metric__label">Заказы в работе</span>
           <span className="metric__value">{orderSummary.inProgress}</span>
@@ -1352,6 +1353,7 @@ export const ProductionDashboard: React.FC = () => {
           </div>
         )}
       </div>
+    </div>
     </section>
   );
 };

--- a/src/features/mes/QualityOperationsBoard.tsx
+++ b/src/features/mes/QualityOperationsBoard.tsx
@@ -42,42 +42,43 @@ export const QualityOperationsBoard: React.FC = () => {
   [nonconformances]);
 
   return (
-    <section className="quality-board" aria-label="Качество и тестирование">
-      <header className="quality-board__header">
-        <div>
+    <section className="mes-layout quality-board" aria-label="Качество и тестирование">
+      <header className="mes-layout__hero">
+        <div className="mes-layout__hero-main">
           <h1>Качество и соответствие</h1>
           <p className="muted">
             Прослеживаемость по контрольным точкам, статус эскалаций и готовность тестовых планов flight control.
           </p>
         </div>
-        <div className="quality-board__actions">
+        <div className="mes-layout__hero-actions quality-board__actions">
           <button type="button" className="primary">Запросить аудит</button>
           <button type="button" className="secondary">Экспортировать 8D отчёт</button>
         </div>
       </header>
-      <div className="quality-board__grid">
-        <article className="quality-card">
-          <header>
-            <h2>КПИ качества</h2>
-          </header>
-          <div className="quality-card__body">
-            <div className="metric">
-              <span className="metric__label">Пройдено</span>
-              <span className="metric__value">
-                {qualityScore ? formatPercent(qualityScore.passed) : '—'}
-              </span>
+      <div className="mes-layout__primary">
+        <div className="quality-board__grid">
+          <article className="mes-card quality-card">
+            <header>
+              <h2>КПИ качества</h2>
+            </header>
+            <div className="quality-card__body">
+              <div className="metric">
+                <span className="metric__label">Пройдено</span>
+                <span className="metric__value">
+                  {qualityScore ? formatPercent(qualityScore.passed) : '—'}
+                </span>
+              </div>
+              <div className="metric">
+                <span className="metric__label">Заблокировано</span>
+                <span className="metric__value">{qualityScore ? qualityScore.blocked : 0}</span>
+              </div>
+              <div className="metric">
+                <span className="metric__label">Записей в журнале</span>
+                <span className="metric__value">{qualityChecks.length}</span>
+              </div>
             </div>
-            <div className="metric">
-              <span className="metric__label">Заблокировано</span>
-              <span className="metric__value">{qualityScore ? qualityScore.blocked : 0}</span>
-            </div>
-            <div className="metric">
-              <span className="metric__label">Записей в журнале</span>
-              <span className="metric__value">{qualityChecks.length}</span>
-            </div>
-          </div>
-        </article>
-        <article className="quality-card quality-card--tall">
+          </article>
+          <article className="mes-card quality-card quality-card--tall">
           <header>
             <h2>Несоответствия</h2>
             <p className="muted">Внимание на высокие степени риска.</p>
@@ -95,7 +96,7 @@ export const QualityOperationsBoard: React.FC = () => {
             {escalations.length === 0 && <li className="muted">Нет открытых инцидентов</li>}
           </ul>
         </article>
-        <article className="quality-card quality-card--tall">
+        <article className="mes-card quality-card quality-card--tall">
           <header>
             <h2>Планы тестирования</h2>
             <p className="muted">Охват и владельцы по каждому обязательному сценарию.</p>
@@ -113,7 +114,7 @@ export const QualityOperationsBoard: React.FC = () => {
             ))}
           </ul>
         </article>
-        <article className="quality-card">
+        <article className="mes-card quality-card">
           <header>
             <h2>Ход тестов</h2>
             <p className="muted">Полевые данные из HIL и burn-in.</p>
@@ -137,6 +138,7 @@ export const QualityOperationsBoard: React.FC = () => {
             </div>
           </div>
         </article>
+        </div>
       </div>
     </section>
   );

--- a/src/features/mes/TestLabControlCenter.tsx
+++ b/src/features/mes/TestLabControlCenter.tsx
@@ -40,82 +40,84 @@ export const TestLabControlCenter: React.FC = () => {
   }, [testCells, testRuns]);
 
   return (
-    <section className="test-lab" aria-label="Контроль тестовой лаборатории">
-      <header className="test-lab__header">
-        <div>
+    <section className="mes-layout test-lab" aria-label="Контроль тестовой лаборатории">
+      <header className="mes-layout__hero">
+        <div className="mes-layout__hero-main">
           <h1>Контроль тестовой лаборатории</h1>
           <p className="muted">Управляйте HIL и burn-in станциями, следите за очередями и планами калибровки.</p>
         </div>
-        <div className="test-lab__actions">
+        <div className="mes-layout__hero-actions test-lab__actions">
           <button type="button" className="primary">Забронировать слот</button>
           <button type="button" className="secondary">Экспорт расписания</button>
         </div>
       </header>
-      <div className="test-lab__grid">
-        <article className="test-lab__card test-lab__card--wide">
-          <header>
-            <h2>Состояние стендов</h2>
-          </header>
-          <ul className="test-lab__cells">
-            {runsByCell.map(({ cell, running, queued, failed }) => {
-              const maintenanceStatus =
-                maintenanceByAsset.get(cell.id) ?? (cell.id.includes('hil') ? maintenanceByAsset.get('wc-hil') : undefined);
-              return (
-                <li key={cell.id}>
-                  <div>
-                    <strong>{cell.name}</strong>
-                    <p className="muted">{cell.capability}</p>
-                    <p className="muted">Смена: {cell.shift}</p>
-                    <p className="muted">Операторы: {cell.operators.join(', ')}</p>
-                    {maintenanceStatus && (
-                      <p className="alert">Обслуживание: {maintenanceStatus}</p>
-                    )}
-                  </div>
-                  <div className="test-lab__cell-stats">
-                    <span className={`status status--${cell.status}`}>{statusLabel[cell.status]}</span>
-                    <span>Очередь: {cell.queueDepth}</span>
-                    <span>В очереди (прогоны): {queued}</span>
-                    <span>Запущено: {running}</span>
-                    <span>Отказов: {failed}</span>
-                    <span>План: {cell.activePlanId ?? '—'}</span>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </article>
-        <article className="test-lab__card">
-          <header>
-            <h2>Распределение прогонов</h2>
-            <p className="muted">Сводка последней смены.</p>
-          </header>
-          <div className="test-lab__runs">
-            {['running', 'queued', 'failed', 'passed'].map(status => (
-              <div key={status}>
-                <span className="metric__label">{statusLabel[status]}</span>
-                <span className="metric__value">{testRuns.filter(run => run.status === status).length}</span>
-              </div>
-            ))}
-          </div>
-        </article>
-        <article className="test-lab__card">
-          <header>
-            <h2>Стандарты и планы</h2>
-            <p className="muted">Следите за актуальностью и покрытием.</p>
-          </header>
-          <ul className="test-lab__plans">
-            {testPlans.map(plan => (
-              <li key={plan.id}>
-                <div>
-                  <strong>{plan.name}</strong>
-                  <p className="muted">Владелец: {plan.ownerTeam}</p>
-                  <p className="muted">Последняя валидация: {new Date(plan.lastValidatedAt).toLocaleString('ru-RU')}</p>
+      <div className="mes-layout__primary">
+        <div className="test-lab__grid">
+          <article className="mes-card test-lab__card test-lab__card--wide">
+            <header>
+              <h2>Состояние стендов</h2>
+            </header>
+            <ul className="test-lab__cells">
+              {runsByCell.map(({ cell, running, queued, failed }) => {
+                const maintenanceStatus =
+                  maintenanceByAsset.get(cell.id) ?? (cell.id.includes('hil') ? maintenanceByAsset.get('wc-hil') : undefined);
+                return (
+                  <li key={cell.id}>
+                    <div>
+                      <strong>{cell.name}</strong>
+                      <p className="muted">{cell.capability}</p>
+                      <p className="muted">Смена: {cell.shift}</p>
+                      <p className="muted">Операторы: {cell.operators.join(', ')}</p>
+                      {maintenanceStatus && (
+                        <p className="alert">Обслуживание: {maintenanceStatus}</p>
+                      )}
+                    </div>
+                    <div className="test-lab__cell-stats">
+                      <span className={`status status--${cell.status}`}>{statusLabel[cell.status]}</span>
+                      <span>Очередь: {cell.queueDepth}</span>
+                      <span>В очереди (прогоны): {queued}</span>
+                      <span>Запущено: {running}</span>
+                      <span>Отказов: {failed}</span>
+                      <span>План: {cell.activePlanId ?? '—'}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </article>
+          <article className="mes-card test-lab__card">
+            <header>
+              <h2>Распределение прогонов</h2>
+              <p className="muted">Сводка последней смены.</p>
+            </header>
+            <div className="test-lab__runs">
+              {['running', 'queued', 'failed', 'passed'].map(status => (
+                <div key={status}>
+                  <span className="metric__label">{statusLabel[status]}</span>
+                  <span className="metric__value">{testRuns.filter(run => run.status === status).length}</span>
                 </div>
-                <span className="metric__value">{Math.round(plan.coverage * 100)}%</span>
-              </li>
-            ))}
-          </ul>
-        </article>
+              ))}
+            </div>
+          </article>
+          <article className="mes-card test-lab__card">
+            <header>
+              <h2>Стандарты и планы</h2>
+              <p className="muted">Следите за актуальностью и покрытием.</p>
+            </header>
+            <ul className="test-lab__plans">
+              {testPlans.map(plan => (
+                <li key={plan.id}>
+                  <div>
+                    <strong>{plan.name}</strong>
+                    <p className="muted">Владелец: {plan.ownerTeam}</p>
+                    <p className="muted">Последняя валидация: {new Date(plan.lastValidatedAt).toLocaleString('ru-RU')}</p>
+                  </div>
+                  <span className="metric__value">{Math.round(plan.coverage * 100)}%</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </div>
       </div>
     </section>
   );

--- a/src/styles/pages/_enterprise.css
+++ b/src/styles/pages/_enterprise.css
@@ -195,9 +195,74 @@
   gap: 1rem;
 }
 
-.mes-production {
+.mes-layout {
   display: grid;
-  gap: 1.75rem;
+  gap: 2rem;
+}
+
+.mes-layout__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(260px, 1fr);
+  align-items: start;
+  gap: 1.5rem;
+}
+
+.mes-layout__hero-main {
+  display: grid;
+  gap: 1rem;
+}
+
+.mes-layout__hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-self: start;
+}
+
+.mes-layout__stats {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.mes-layout__columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 2.4fr) minmax(260px, 1fr);
+  align-items: start;
+}
+
+.mes-layout__primary,
+.mes-layout__secondary {
+  display: grid;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.mes-layout__full {
+  grid-column: 1 / -1;
+}
+
+.mes-card {
+  background: var(--surface-card);
+  border-radius: 18px;
+  padding: 1.4rem;
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 1rem;
+}
+
+.mes-card--muted {
+  background: var(--surface-subtle);
+  border: 1px solid var(--border-subtle);
+  box-shadow: none;
+}
+
+@media (max-width: 1200px) {
+  .mes-layout__hero,
+  .mes-layout__columns {
+    grid-template-columns: 1fr;
+  }
 }
 
 .mes-production__summary {
@@ -663,15 +728,6 @@
 }
 
 
-.mes-command {
-  display: grid;
-  gap: 1.75rem;
-}
-
-.mes-command__header,
-.mes-production__header,
-.quality-board__header,
-.test-lab__header,
 .workforce__header {
   display: flex;
   justify-content: space-between;
@@ -892,34 +948,13 @@
   min-width: 0;
 }
 
-.firmware-console {
-  display: grid;
-  gap: 2rem;
-}
-
-.firmware-console__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-}
-
 .firmware-console__metrics {
-  margin-top: 1.25rem;
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-top: 0.75rem;
 }
 
 .firmware-console__agents {
-  background: var(--surface-card);
-  border-radius: 18px;
-  padding: 1.2rem;
-  box-shadow: var(--shadow-md);
-  display: grid;
-  gap: 1rem;
   min-width: 260px;
+  padding: 1.25rem;
 }
 
 .firmware-console__agents ul {
@@ -943,14 +978,14 @@
   color: var(--text-muted);
 }
 
-.firmware-console__content {
+.firmware-console__workspace {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
 }
 
 @media (max-width: 1200px) {
-  .firmware-console__content {
+  .firmware-console__workspace {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a shared `mes-layout` grid pattern and reusable card styling for MES views
- rebuild the firmware flashing console into a multi-column dashboard with cards, sidebar and summary
- apply the new layout structure to other MES pages to unify spacing, headers and responsive behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12a02a1a0832196faf1da336b5229